### PR TITLE
Helper functions and logging

### DIFF
--- a/src/GraphQL.Conventions/Attributes/MetaData/NameAttribute.cs
+++ b/src/GraphQL.Conventions/Attributes/MetaData/NameAttribute.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using GraphQL.Conventions.Attributes;
 using GraphQL.Conventions.Attributes.Collectors;
 using GraphQL.Conventions.Attributes.MetaData.Utilities;
-using GraphQL.Conventions.Types;
 using GraphQL.Conventions.Types.Descriptors;
 using GraphQL.Conventions.Types.Resolution.Extensions;
 

--- a/src/GraphQL.Conventions/Builders/SchemaConstructor.cs
+++ b/src/GraphQL.Conventions/Builders/SchemaConstructor.cs
@@ -36,15 +36,20 @@ namespace GraphQL.Conventions.Builders
             Build(typeof(TSchema).GetTypeInfo());
 
         public TSchemaType Build(params Type[] schemaTypes) =>
-            Build(schemaTypes.Select(type => type.GetTypeInfo()).ToArray());
+            Build(schemaTypes?.Select(type => type.GetTypeInfo()).ToArray());
 
         public TSchemaType Build(params TypeInfo[] schemaTypes)
         {
-            var schemaInfos = schemaTypes
+            var schemaInfos = schemaTypes?
                 .Select(_typeResolver.DeriveSchema)
-                .ToList();
+                .ToList() ?? new List<GraphSchemaInfo>();
 
             var schemaInfo = schemaInfos.FirstOrDefault();
+            if (schemaInfo == null)
+            {
+                return null;
+            }
+
             schemaInfo.TypeResolutionDelegate = TypeResolutionDelegate;
 
             foreach (var additionalSchemaInfo in schemaInfos.Skip(1))

--- a/src/GraphQL.Conventions/CommonAssemblyInfo.cs
+++ b/src/GraphQL.Conventions/CommonAssemblyInfo.cs
@@ -7,9 +7,9 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyProduct("GraphQL.Conventions")]
 [assembly: AssemblyCopyright("Copyright 2016-2017 Tommy Lillehagen. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
-[assembly: AssemblyInformationalVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyFileVersion("1.1.1.0")]
+[assembly: AssemblyInformationalVersion("1.1.1.0")]
 [assembly: CLSCompliant(false)]
 
 [assembly: InternalsVisibleTo("GraphQL.Conventions.Tests")]

--- a/src/GraphQL.Conventions/Types/Id.cs
+++ b/src/GraphQL.Conventions/Types/Id.cs
@@ -25,6 +25,14 @@ namespace GraphQL.Conventions
                 ? $"{typeName}:{identifier}"
                 : $"{typeName}{identifier}";
             _encodedIdentifier = Types.Utilities.Identifier.Encode(_unencodedIdentifier);
+            if (string.IsNullOrWhiteSpace(identifier))
+            {
+                throw new ArgumentException($"Invalid blank identifier '{_unencodedIdentifier}'.");
+            }
+            if (string.IsNullOrWhiteSpace(_unencodedIdentifier))
+            {
+                throw new ArgumentException($"Unable to encode identifier '{_unencodedIdentifier}'.");
+            }
         }
 
         public Id(string encodedIdentifier)
@@ -56,7 +64,9 @@ namespace GraphQL.Conventions
             _encodedIdentifier;
 
         public bool IsIdentifierForType(Type type) =>
-            _unencodedIdentifier.StartsWith(GetTypeName(type));
+            _unencodedIdentifier.Contains(":")
+            ? _unencodedIdentifier.StartsWith(GetTypeName(type) + ":")
+            : _unencodedIdentifier.StartsWith(GetTypeName(type));
 
         public bool IsIdentifierForType<TType>() =>
             IsIdentifierForType(typeof(TType));
@@ -69,7 +79,12 @@ namespace GraphQL.Conventions
                 throw new ArgumentException(
                     $"Expected identifier of type '{typeName}' (unencoded identifier '{_unencodedIdentifier}').");
             }
-            return _unencodedIdentifier.Remove(0, typeName.Length).TrimStart(':');
+            var underlyingIdentifier = _unencodedIdentifier.Remove(0, typeName.Length).TrimStart(':');
+            if (string.IsNullOrWhiteSpace(underlyingIdentifier))
+            {
+                throw new ArgumentException($"Invalid blank identifier '{_unencodedIdentifier}'.");
+            }
+            return underlyingIdentifier;
         }
 
         public string IdentifierForType<TType>() =>

--- a/src/GraphQL.Conventions/Types/Resolution/ObjectReflector.cs
+++ b/src/GraphQL.Conventions/Types/Resolution/ObjectReflector.cs
@@ -2,11 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using GraphQL.Conventions.Execution;
 using GraphQL.Conventions.Handlers;
 using GraphQL.Conventions.Types.Descriptors;
 using GraphQL.Conventions.Types.Resolution.Extensions;
-using GraphQL.Conventions.Utilities;
 
 namespace GraphQL.Conventions.Types.Resolution
 {

--- a/src/GraphQL.Conventions/Types/Utilities/EnumerableExtensions.cs
+++ b/src/GraphQL.Conventions/Types/Utilities/EnumerableExtensions.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GraphQL.Conventions
+{
+    public static class EnumerableExtensions
+    {
+        public static IEnumerable<V> Select<U, V>(this NonNull<IEnumerable<U>> list, Func<U, V> selector) =>
+            list.Value.Select(selector);
+
+        public static IEnumerable<V> Select<U, V>(this NonNull<List<U>> list, Func<U, V> selector) =>
+            list.Value.Select(selector);
+
+        public static IEnumerable<U> Where<U>(this NonNull<IEnumerable<U>> list, Func<U, bool> predicate) =>
+            list.Value.Where(predicate);
+
+        public static IEnumerable<U> Where<U>(this NonNull<List<U>> list, Func<U, bool> predicate) =>
+            list.Value.Where(predicate);
+
+        public static U FirstOrDefault<U>(this NonNull<IEnumerable<U>> list, Func<U, bool> predicate) =>
+            list.Value.FirstOrDefault(predicate);
+
+        public static U FirstOrDefault<U>(this NonNull<List<U>> list, Func<U, bool> predicate) =>
+            list.Value.FirstOrDefault(predicate);
+
+        public static U First<U>(this NonNull<IEnumerable<U>> list, Func<U, bool> predicate) =>
+            list.Value.First(predicate);
+
+        public static U First<U>(this NonNull<List<U>> list, Func<U, bool> predicate) =>
+            list.Value.First(predicate);
+    }
+}

--- a/src/GraphQL.Conventions/Types/Utilities/Utilities.cs
+++ b/src/GraphQL.Conventions/Types/Utilities/Utilities.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GraphQL.Conventions
+{
+    public static class Utilities
+    {
+        public static NonNull<IEnumerable<T>> NonNull<T>(IEnumerable<T> items) => items.ToList();
+
+        public static NonNull<List<T>> NonNull<T>(List<T> items) => items;
+
+        public static NonNull<string> NonNull(string str) => str;
+
+        public static Id Id(string encodedIdentifier) => new Id(encodedIdentifier);
+
+        public static Id Id<T>(string unencodedIdentifier, bool serializeUsingColon = true) =>
+            GraphQL.Conventions.Id.New<T>(unencodedIdentifier, serializeUsingColon);
+    }
+}

--- a/src/GraphQL.Conventions/Utilities/CachedRegistry.cs
+++ b/src/GraphQL.Conventions/Utilities/CachedRegistry.cs
@@ -2,9 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace GraphQL.Conventions.Utilities
+namespace GraphQL.Conventions
 {
-    public class CachedRegistry<TKey, TValue>
+    class CachedRegistry<TKey, TValue>
     {
         private object _lock = new object();
 

--- a/src/GraphQL.Conventions/Utilities/ILogger.cs
+++ b/src/GraphQL.Conventions/Utilities/ILogger.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace GraphQL.Conventions
+{
+    public interface ILogger
+    {
+        void Trace(string message);
+
+        void Info(string message);
+
+        void Warning(string message, Exception exception = null);
+
+        void Error(string message, Exception exception = null);
+    }
+}

--- a/src/GraphQL.Conventions/project.json
+++ b/src/GraphQL.Conventions/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0-*",
+  "version": "1.1.1-*",
   "description": "GraphQL Conventions for .NET",
   "authors": [
     "Tommy Lillehagen"

--- a/test/GraphQL.Conventions.Tests/Types/IdTests.cs
+++ b/test/GraphQL.Conventions.Tests/Types/IdTests.cs
@@ -2,6 +2,7 @@ using System;
 using GraphQL.Conventions.Tests.Templates;
 using GraphQL.Conventions.Tests.Templates.Extensions;
 using GraphQL.Conventions.Types.Utilities;
+using static GraphQL.Conventions.Utilities;
 using Xunit;
 
 namespace GraphQL.Conventions.Tests.Types
@@ -11,22 +12,22 @@ namespace GraphQL.Conventions.Tests.Types
         [Fact]
         public void Can_Instantiate_Identifier_From_Encoded_String()
         {
-            var id = new Id("VGVzdDoxMjM0NQ==");
+            var id = Id("VGVzdDoxMjM0NQ==");
             id.IdentifierForType<Test>().ShouldEqual("12345");
         }
 
         [Fact]
         public void Cannot_Instantiate_Identifier_From_Encoded_String_Of_Wrong_Type()
         {
-            var id = new Id("VGVzdDoxMjM0NQ==");
+            var id = Id("VGVzdDoxMjM0NQ==");
             Assert.Throws<ArgumentException>(() => id.IdentifierForType<AnotherTest>());
         }
 
         [Fact]
         public void Cannot_Instantiate_Identifier_From_Empty_String()
         {
-            Assert.Throws<ArgumentException>(() => new Id(null));
-            Assert.Throws<ArgumentException>(() => new Id(string.Empty));
+            Assert.Throws<ArgumentException>(() => Id(null));
+            Assert.Throws<ArgumentException>(() => Id(string.Empty));
             var nullableId = (Id?)null;
             nullableId.HasValue.ShouldEqual(false);
         }
@@ -34,17 +35,17 @@ namespace GraphQL.Conventions.Tests.Types
         [Fact]
         public void Cannot_Instantiate_Identifier_From_Invalid_Base64_String()
         {
-            Assert.Throws<ArgumentException>(() => new Id("abcdef"));
+            Assert.Throws<ArgumentException>(() => Id("abcdef"));
         }
 
         [Fact]
         public void Can_Sort_Identifiers_Serialized_Using_Colon_Separators()
         {
-            var id0 = Id.New<IdTests>("12345", true);
-            var id1 = Id.New<IdTests>("12345", true);
-            var id2 = Id.New<IdTests>("1235", true);
-            var id3 = Id.New<IdTests>("99231", true);
-            var id4 = Id.New<TestBase>("99231", true);
+            var id0 = Id<IdTests>("12345", true);
+            var id1 = Id<IdTests>("12345", true);
+            var id2 = Id<IdTests>("1235", true);
+            var id3 = Id<IdTests>("99231", true);
+            var id4 = Id<TestBase>("99231", true);
 
             Assert.True(Identifier.Decode(id0.ToString()).Contains(":"));
             Assert.True(id0 == id1);
@@ -65,11 +66,11 @@ namespace GraphQL.Conventions.Tests.Types
         [Fact]
         public void Can_Sort_Identifiers_Serialized_Without_Using_Colon_Separators()
         {
-            var id0 = Id.New<IdTests>("12345", false);
-            var id1 = Id.New<IdTests>("12345", false);
-            var id2 = Id.New<IdTests>("1235", false);
-            var id3 = Id.New<IdTests>("99231", false);
-            var id4 = Id.New<TestBase>("99231", false);
+            var id0 = Id<IdTests>("12345", false);
+            var id1 = Id<IdTests>("12345", false);
+            var id2 = Id<IdTests>("1235", false);
+            var id3 = Id<IdTests>("99231", false);
+            var id4 = Id<TestBase>("99231", false);
 
             Assert.False(Identifier.Decode(id0.ToString()).Contains(":"));
             Assert.True(id0 == id1);
@@ -87,11 +88,42 @@ namespace GraphQL.Conventions.Tests.Types
             Assert.True(id3 != id4);
         }
 
+        [Fact]
+        public void Can_Decode_Identifiers_Unambiguously_When_Serialized_With_Colon()
+        {
+            Id<TestItem>("12345").IsIdentifierForType<Test>()
+                .ShouldBeFalse("Identifier for type 'TestItem' thought to be an identifier for type 'Test'.");
+            Id<Test>("12345").IsIdentifierForType<TestItem>()
+                .ShouldBeFalse("Identifier for type 'Test' thought to be an identifier for type 'TestItem'.");
+        }
+
+        [Fact]
+        public void Can_Decode_Identifiers_Unambiguously_When_Serialized_Without_Colon()
+        {
+            Id<TestItem>("12345", false).IsIdentifierForType<Test>()
+                .ShouldEqual(true); // Cannot distinguish between the two as it could either be: {'Test', 'Item12345'} or {'TestItem', '12345'}
+            Id<Test>("12345", false).IsIdentifierForType<TestItem>()
+                .ShouldBeFalse("Identifier for type 'Test' thought to be an identifier for type 'TestItem'.");
+        }
+
+        [Fact]
+        public void Cannot_Decode_Empty_Identifiers()
+        {
+            Assert.Throws<ArgumentException>(() => Id<Test>("", true).IdentifierForType<Test>());
+            Assert.Throws<ArgumentException>(() => Id<Test>("", false).IdentifierForType<Test>());
+            Assert.Throws<ArgumentException>(() => Id("VGVzdDo=").IdentifierForType<Test>());
+            Assert.Throws<ArgumentException>(() => Id("VGVzdA==").IdentifierForType<Test>());
+        }
+
         class Test
         {
         }
 
         class AnotherTest
+        {
+        }
+
+        class TestItem
         {
         }
     }


### PR DESCRIPTION
 * Add helper functions and extensions for simplify initialisation of
   IDs and non-nulls.
 * Don't fall over if no schemas are passed into the schema constructor.
 * Add optional, injectable logging capabilities to the graph type
   adapter.