### PR TITLE
Validation and New Types (Guid, DateTimeOffset)

### DIFF
--- a/src/GraphQL.Conventions/CommonAssemblyInfo.cs
+++ b/src/GraphQL.Conventions/CommonAssemblyInfo.cs
@@ -7,9 +7,9 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyProduct("GraphQL.Conventions")]
 [assembly: AssemblyCopyright("Copyright 2016-2017 Tommy Lillehagen. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyVersion("1.1.8.0")]
-[assembly: AssemblyFileVersion("1.1.8.0")]
-[assembly: AssemblyInformationalVersion("1.1.8.0")]
+[assembly: AssemblyVersion("1.1.9.0")]
+[assembly: AssemblyFileVersion("1.1.9.0")]
+[assembly: AssemblyInformationalVersion("1.1.9.0")]
 [assembly: CLSCompliant(false)]
 
 [assembly: InternalsVisibleTo("GraphQL.Conventions.Tests")]

--- a/src/GraphQL.Conventions/Web/IRequestHandler.cs
+++ b/src/GraphQL.Conventions/Web/IRequestHandler.cs
@@ -6,6 +6,8 @@ namespace GraphQL.Conventions.Web
     {
         Task<Response> ProcessRequest(Request request, IUserContext userContext);
 
+        Response Validate(Request request);
+
         string DescribeSchema(bool returnJson = false);
     }
 }

--- a/src/GraphQL.Conventions/Web/Response.cs
+++ b/src/GraphQL.Conventions/Web/Response.cs
@@ -37,8 +37,8 @@ namespace GraphQL.Conventions.Web
 
         public bool IsValid => ValidationResult != null ? ValidationResult.IsValid : !HasErrors;
 
-        public IList<ExecutionError> Errors { get; } = new List<ExecutionError>();
+        public List<ExecutionError> Errors { get; } = new List<ExecutionError>();
 
-        public IList<ExecutionError> Warnings { get; } = new List<ExecutionError>();
+        public List<ExecutionError> Warnings { get; } = new List<ExecutionError>();
     }
 }

--- a/src/GraphQL.Conventions/project.json
+++ b/src/GraphQL.Conventions/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.8-*",
+  "version": "1.1.9-*",
   "description": "GraphQL Conventions for .NET",
   "authors": [
     "Tommy Lillehagen"


### PR DESCRIPTION
 * Expose `IRequestHandler.Validate()` (previously only on `RequestHandler`)
 * Add `Guid` and `DateTimeOffset` types
 * Update `xunit` to 2.2.0 release
 * Add `WithoutValidation(outputViolationsAsWarnings = false)` to disable validation (setting the optional flag to `true` will collate the validation errors into `Response.Warnings`)