### PR TITLE
JSON.NET 5.0.6

### DIFF
--- a/src/GraphQL.Conventions/CommonAssemblyInfo.cs
+++ b/src/GraphQL.Conventions/CommonAssemblyInfo.cs
@@ -8,8 +8,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright("Copyright 2016-2017 Tommy Lillehagen. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.2.2")]
-[assembly: AssemblyInformationalVersion("1.2.2")]
+[assembly: AssemblyFileVersion("1.2.3")]
+[assembly: AssemblyInformationalVersion("1.2.3")]
 [assembly: CLSCompliant(false)]
 
 [assembly: InternalsVisibleTo("GraphQL.Conventions.Tests")]

--- a/src/GraphQL.Conventions/GraphQL.Conventions.csproj
+++ b/src/GraphQL.Conventions/GraphQL.Conventions.csproj
@@ -32,7 +32,7 @@
 
   <ItemGroup>
     <PackageReference Include="GraphQL-Parser" Version="2.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="5.0.6" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">

--- a/src/GraphQL.Conventions/GraphQL.Conventions.csproj
+++ b/src/GraphQL.Conventions/GraphQL.Conventions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>GraphQL Conventions for .NET</Description>
-    <VersionPrefix>1.2.2</VersionPrefix>
+    <VersionPrefix>1.2.3</VersionPrefix>
     <Authors>Tommy Lillehagen</Authors>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <DebugType>portable</DebugType>

--- a/src/GraphQL.Conventions/project.json
+++ b/src/GraphQL.Conventions/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.2-*",
+  "version": "1.2.3-*",
   "description": "GraphQL Conventions for .NET",
   "authors": [
     "Tommy Lillehagen"

--- a/src/GraphQL.Conventions/project.json
+++ b/src/GraphQL.Conventions/project.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "GraphQL-Parser": "2.0.0",
-    "Newtonsoft.Json": "9.0.1"
+    "Newtonsoft.Json": "5.0.6"
   },
   "frameworks": {
     "netstandard1.5": {


### PR DESCRIPTION
- Fix dependency on JSON.NET to version 5.0.6
  _(feel free to ignore this release as it's a workaround for internal dependencies on our end)_