### PR TITLE
Give each executor its own IDependencyInjector #49

### DIFF
--- a/src/GraphQL.Conventions/Adapters/Engine/GraphQLExecutor.cs
+++ b/src/GraphQL.Conventions/Adapters/Engine/GraphQLExecutor.cs
@@ -24,6 +24,8 @@ namespace GraphQL.Conventions
 
         private CancellationToken _cancellationToken = default(CancellationToken);
 
+        private IDependencyInjector _dependencyInjector;
+
         private bool _enableValidation = true;
 
         private bool _enableProfiling = false;
@@ -84,7 +86,7 @@ namespace GraphQL.Conventions
 
         public IGraphQLExecutor<ExecutionResult> WithDependencyInjector(IDependencyInjector injector)
         {
-            _engine.DependencyInjector = injector;
+            _dependencyInjector = injector;
             return this;
         }
 
@@ -125,7 +127,7 @@ namespace GraphQL.Conventions
         public async Task<ExecutionResult> Execute() =>
             await _engine
                 .Execute(
-                    _rootObject, _queryString, _operationName, _inputs, _userContext,
+                    _rootObject, _queryString, _operationName, _inputs, _userContext, _dependencyInjector,
                     enableValidation: _enableValidation,
                     enableProfiling: _enableProfiling,
                     rules: _validationRules,

--- a/src/GraphQL.Conventions/Adapters/ResolutionContext.cs
+++ b/src/GraphQL.Conventions/Adapters/ResolutionContext.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using GraphQL.Conventions.Execution;
 using GraphQL.Conventions.Types.Descriptors;
 using GraphQL.Types;
 
@@ -56,7 +57,9 @@ namespace GraphQL.Conventions.Adapters
 
         public object RootValue => FieldContext.RootValue;
 
-        public IUserContext UserContext => FieldContext.UserContext as IUserContext;
+        public IUserContext UserContext => (FieldContext.UserContext as UserContextWrapper)?.UserContext;
+
+        public IDependencyInjector DependencyInjector => (FieldContext.UserContext as UserContextWrapper)?.DependencyInjector;
 
         public GraphFieldInfo FieldInfo { get; private set; }
 

--- a/src/GraphQL.Conventions/Adapters/Resolvers/FieldResolver.cs
+++ b/src/GraphQL.Conventions/Adapters/Resolvers/FieldResolver.cs
@@ -70,7 +70,7 @@ namespace GraphQL.Conventions.Adapters
                 source.GetType() == typeof(ImplementViewerAttribute.SubscriptionViewer))
             {
                 var declaringType = fieldInfo.DeclaringType.TypeRepresentation.AsType();
-                source = fieldInfo.SchemaInfo.TypeResolutionDelegate(declaringType);
+                source = context.DependencyInjector?.Resolve(declaringType.GetTypeInfo()) ?? fieldInfo.SchemaInfo.TypeResolutionDelegate(declaringType);
             }
             source = Unwrapper.Unwrap(source);
             return source;

--- a/src/GraphQL.Conventions/Adapters/Resolvers/WrappedAsyncFieldResolver.cs
+++ b/src/GraphQL.Conventions/Adapters/Resolvers/WrappedAsyncFieldResolver.cs
@@ -83,7 +83,7 @@ namespace GraphQL.Conventions.Adapters
                 source.GetType() == typeof(ImplementViewerAttribute.SubscriptionViewer))
             {
                 var declaringType = fieldInfo.DeclaringType.TypeRepresentation.AsType();
-                source = fieldInfo.SchemaInfo.TypeResolutionDelegate(declaringType);
+                source = context.DependencyInjector?.Resolve(declaringType.GetTypeInfo()) ?? fieldInfo.SchemaInfo.TypeResolutionDelegate(declaringType);
             }
             source = Unwrapper.Unwrap(source);
             return source;

--- a/src/GraphQL.Conventions/Adapters/Resolvers/WrappedSyncFieldResolver.cs
+++ b/src/GraphQL.Conventions/Adapters/Resolvers/WrappedSyncFieldResolver.cs
@@ -82,7 +82,7 @@ namespace GraphQL.Conventions.Adapters
                 source.GetType() == typeof(ImplementViewerAttribute.SubscriptionViewer))
             {
                 var declaringType = fieldInfo.DeclaringType.TypeRepresentation.AsType();
-                source = fieldInfo.SchemaInfo.TypeResolutionDelegate(declaringType);
+                source = context.DependencyInjector?.Resolve(declaringType.GetTypeInfo()) ?? fieldInfo.SchemaInfo.TypeResolutionDelegate(declaringType);
             }
             source = Unwrapper.Unwrap(source);
             return source;

--- a/src/GraphQL.Conventions/Execution/IResolutionContext.cs
+++ b/src/GraphQL.Conventions/Execution/IResolutionContext.cs
@@ -17,6 +17,8 @@ namespace GraphQL.Conventions
 
         IUserContext UserContext { get; }
 
+        IDependencyInjector DependencyInjector { get; }
+
         GraphFieldInfo FieldInfo { get; }
 
         CancellationToken CancellationToken { get; }

--- a/src/GraphQL.Conventions/Execution/UserContextWrapper.cs
+++ b/src/GraphQL.Conventions/Execution/UserContextWrapper.cs
@@ -1,0 +1,15 @@
+﻿namespace GraphQL.Conventions.Execution
+{
+    internal class UserContextWrapper
+    {
+        public UserContextWrapper(IUserContext userContext, IDependencyInjector dependencyInjector)
+        {
+            UserContext = userContext;
+            DependencyInjector = dependencyInjector;
+        }
+
+        public IUserContext UserContext { get; }
+
+        public IDependencyInjector DependencyInjector { get; }
+    }
+}

--- a/src/GraphQL.Conventions/Handlers/ExecutionFilterAttributeHandler.cs
+++ b/src/GraphQL.Conventions/Handlers/ExecutionFilterAttributeHandler.cs
@@ -59,7 +59,7 @@ namespace GraphQL.Conventions.Handlers
                 }
                 else
                 {
-                    obj = argument.TypeResolver.DependencyInjector?.Resolve(argumentType);
+                    obj = resolutionContext.DependencyInjector?.Resolve(argumentType);
                 }
                 resolutionContext.SetArgument(argument.Name, obj);
             }

--- a/src/GraphQL.Conventions/Types/Resolution/ITypeResolver.cs
+++ b/src/GraphQL.Conventions/Types/Resolution/ITypeResolver.cs
@@ -19,8 +19,6 @@ namespace GraphQL.Conventions.Types.Resolution
 
         TypeRegistration LookupType(TypeInfo typeInfo);
 
-        IDependencyInjector DependencyInjector { get; set; }
-
         GraphSchemaInfo ActiveSchema { get; set; }
     }
 }

--- a/src/GraphQL.Conventions/Types/Resolution/TypeResolver.cs
+++ b/src/GraphQL.Conventions/Types/Resolution/TypeResolver.cs
@@ -61,8 +61,6 @@ namespace GraphQL.Conventions.Types.Resolution
             _reflector.DiscoverAndRegisterDefaultAttributesInAssembly(assemblyType);
         }
 
-        public IDependencyInjector DependencyInjector { get; set; }
-
         public GraphSchemaInfo ActiveSchema { get; set; }
 
         private void RegisterKnownTypes()


### PR DESCRIPTION
In short: the resolution delegate passed to the GraphQLEngine constructor is passed to the schema constructor (one shared instance for all executors like it was before), while the dependency resolver set on the executor, is passed to a wrapped user context object. During field resolving, we use the dependency resolver of the context if any, otherwise fallback to the global resolution delegate. I've added a unit tests which clearly illustrates the problem.

For the library consumer perspective, nothing has changed.