### PR TITLE
Invalidate empty query, and profiling extensions

### DIFF
--- a/deps/graphql-dotnet/src/GraphQL/Execution/ExecutionResult.cs
+++ b/deps/graphql-dotnet/src/GraphQL/Execution/ExecutionResult.cs
@@ -1,4 +1,5 @@
-﻿using GraphQL.Instrumentation;
+﻿using System.Collections.Generic;
+using GraphQL.Instrumentation;
 using GraphQL.Language.AST;
 using Newtonsoft.Json;
 
@@ -10,6 +11,9 @@ namespace GraphQL
         public object Data { get; set; }
 
         public ExecutionErrors Errors { get; set; }
+
+        public Dictionary<string, object> Extra { get; private set; } =
+            new Dictionary<string, object>();
 
         public string Query { get; set; }
 

--- a/deps/graphql-dotnet/src/GraphQL/Execution/ExecutionResultJsonConverter.cs
+++ b/deps/graphql-dotnet/src/GraphQL/Execution/ExecutionResultJsonConverter.cs
@@ -18,6 +18,7 @@ namespace GraphQL
 
                 writeData(result, writer, serializer);
                 writeErrors(result.Errors, writer, serializer, result.ExposeExceptions);
+                writeExtra(result, writer, serializer);
 
                 writer.WriteEndObject();
             }
@@ -111,6 +112,23 @@ namespace GraphQL
             });
 
             writer.WriteEndArray();
+        }
+
+        private void writeExtra(ExecutionResult result, JsonWriter writer, JsonSerializer serializer)
+        {
+            if (result.Extra == null || result.Extra.Count == 0)
+            {
+                return;
+            }
+
+            writer.WritePropertyName("extra");
+            writer.WriteStartObject();
+            result.Extra.Apply(kvp =>
+            {
+                writer.WritePropertyName(kvp.Key);
+                serializer.Serialize(writer, kvp.Value);
+            });
+            writer.WriteEndObject();
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)

--- a/src/GraphQL.Conventions/CommonAssemblyInfo.cs
+++ b/src/GraphQL.Conventions/CommonAssemblyInfo.cs
@@ -8,8 +8,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright("Copyright 2016-2017 Tommy Lillehagen. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.3.4")]
-[assembly: AssemblyInformationalVersion("1.3.4")]
+[assembly: AssemblyFileVersion("1.3.5")]
+[assembly: AssemblyInformationalVersion("1.3.5")]
 [assembly: CLSCompliant(false)]
 
 [assembly: InternalsVisibleTo("Tests")]

--- a/src/GraphQL.Conventions/Extensions/ChaosAttribute.cs
+++ b/src/GraphQL.Conventions/Extensions/ChaosAttribute.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using GraphQL.Conventions;
+using GraphQL.Conventions.Attributes;
+using GraphQL.Conventions.Attributes.Collectors;
+using GraphQL.Conventions.Execution;
+using GraphQL.Conventions.Types.Descriptors;
+
+namespace GraphQL.Conventions.Extensions
+{
+    public class ChaosAttribute : ExecutionFilterAttributeBase
+    {
+        public static bool IsEnabled = false;
+
+        private const int DefaultSuccessRate = 50;
+
+        private static readonly Random _random = new Random();
+
+        private readonly int _successRate;
+
+        public ChaosAttribute(int successRate = DefaultSuccessRate)
+        {
+            _successRate = successRate;
+        }
+
+        public override Task<object> Execute(IResolutionContext context, FieldResolutionDelegate next)
+        {
+            if (_random.Next(0, 100) > _successRate)
+            {
+                var path = $"{context.FieldInfo.DeclaringType.Name}.{context.FieldInfo.Name}";
+                throw new ChaosException($"Only {_successRate} % of requests will succeed.", path);
+            }
+            return next(context);
+        }
+    }
+
+    public class ChaosMetaDataAttribute : MetaDataAttributeBase, IDefaultAttribute
+    {
+        public override void MapField(GraphFieldInfo entity, MemberInfo memberInfo)
+        {
+            if (ChaosAttribute.IsEnabled)
+            {
+                entity.ExecutionFilters.Add(new ChaosAttribute());
+            }
+        }
+    }
+
+    public class ChaosException : Exception
+    {
+        public ChaosException(string message, string path)
+            : base(message)
+        {
+            Path = path;
+        }
+
+        public string Path { get; private set; }
+    }
+}

--- a/src/GraphQL.Conventions/Extensions/NameNormalizerAttribute.cs
+++ b/src/GraphQL.Conventions/Extensions/NameNormalizerAttribute.cs
@@ -1,0 +1,23 @@
+using System.Reflection;
+using GraphQL.Conventions.Attributes;
+using GraphQL.Conventions.Attributes.Collectors;
+using GraphQL.Conventions.Types.Descriptors;
+
+namespace GraphQL.Conventions.Extensions
+{
+    public class NameNormalizerAttribute : MetaDataAttributeBase, IDefaultAttribute
+    {
+        public NameNormalizerAttribute()
+            : base(AttributeApplicationPhase.Override)
+        {
+        }
+
+        public override void MapType(GraphTypeInfo entity, TypeInfo typeInfo)
+        {
+            if (entity.Name?.EndsWith("Dto") ?? false)
+            {
+                entity.Name = entity.Name.Remove(entity.Name.Length - 3);
+            }
+        }
+    }
+}

--- a/src/GraphQL.Conventions/Extensions/Profiling/PerformanceRecord.cs
+++ b/src/GraphQL.Conventions/Extensions/Profiling/PerformanceRecord.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace GraphQL.Conventions.Extensions
+{
+    public class PerformanceRecord
+    {
+        [JsonProperty(PropertyName = "path")]
+        public string Path { get; set; }
+
+        [JsonProperty(PropertyName = "start")]
+        public long StartTimeInMs { get; set; }
+
+        [JsonProperty(PropertyName = "end")]
+        public long EndTimeInMs { get; set; }
+
+        [JsonProperty(PropertyName = "type")]
+        public string ParentType { get; set; }
+
+        [JsonProperty(PropertyName = "field")]
+        public string Field { get; set; }
+
+        [JsonProperty(PropertyName = "args")]
+        public Dictionary<string, object> Arguments { get; set; }
+    }
+}

--- a/src/GraphQL.Conventions/Extensions/Profiling/ProfilingResultEnricher.cs
+++ b/src/GraphQL.Conventions/Extensions/Profiling/ProfilingResultEnricher.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Linq;
+using GraphQL.Conventions;
+using GraphQL.Conventions.Web;
+
+namespace GraphQL.Conventions.Extensions
+{
+    public static class ProfilingResultEnricher
+    {
+        public static void EnrichWithProfilingInformation(this Response response)
+        {
+            var perf = response?.ExecutionResult?.Perf;
+            if (perf == null) { return; }
+
+            var records = new List<PerformanceRecord>();
+            foreach (var record in perf)
+            {
+                if (record.Category != "field") { continue; }
+
+                records.Add(new PerformanceRecord
+                {
+                    Path = string.Join(".", record.Metadata["path"] as List<string>),
+                    StartTimeInMs = record.Start,
+                    EndTimeInMs = record.End,
+                    ParentType = record.Metadata["typeName"] as string,
+                    Field = record.Metadata["fieldName"] as string,
+                    Arguments = record.Metadata["arguments"] as Dictionary<string, object>,
+                });
+            }
+
+            if (records.Any())
+            {
+                response.AddExtra("profile", records.OrderBy(record => record.Path));
+            }
+        }
+    }
+}

--- a/src/GraphQL.Conventions/Extensions/Utilities.cs
+++ b/src/GraphQL.Conventions/Extensions/Utilities.cs
@@ -1,0 +1,26 @@
+using GraphQL.Conventions;
+using GraphQL.Conventions.Web;
+
+namespace GraphQL.Conventions.Extensions
+{
+    public static class Utilities
+    {
+        public static string IdentifierForTypeOrNull<T>(this string id) =>
+            id.IsIdentifierForType<T>() ? id.IdentifierForType<T>() : null;
+
+        public static string IdentifierForTypeOrNull<T>(this NonNull<string> id) =>
+            id.IsIdentifierForType<T>() ? id.IdentifierForType<T>() : null;
+
+        public static string IdentifierForType<T>(this string id) =>
+            new Id(id).IdentifierForType<T>();
+
+        public static string IdentifierForType<T>(this NonNull<string> id) =>
+            id.Value.IdentifierForType<T>();
+
+        public static bool IsIdentifierForType<T>(this string id) =>
+            new Id(id).IsIdentifierForType<T>();
+
+        public static bool IsIdentifierForType<T>(this NonNull<string> id) =>
+            id.Value.IsIdentifierForType<T>();
+    }
+}

--- a/src/GraphQL.Conventions/GraphQL.Conventions.csproj
+++ b/src/GraphQL.Conventions/GraphQL.Conventions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>GraphQL Conventions for .NET</Description>
-    <VersionPrefix>1.3.4</VersionPrefix>
+    <VersionPrefix>1.3.5</VersionPrefix>
     <Authors>Tommy Lillehagen</Authors>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <DebugType>portable</DebugType>

--- a/src/GraphQL.Conventions/Web/Request.cs
+++ b/src/GraphQL.Conventions/Web/Request.cs
@@ -58,6 +58,11 @@ namespace GraphQL.Conventions.Web
             : this()
         {
             _queryInput = queryInput;
+
+            if (string.IsNullOrWhiteSpace(_queryInput.QueryString))
+            {
+                _exception = new ArgumentException($"Empty query string");
+            }
         }
 
         Request(Exception exception)

--- a/src/GraphQL.Conventions/Web/Response.cs
+++ b/src/GraphQL.Conventions/Web/Response.cs
@@ -1,10 +1,16 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using GraphQL.Http;
 
 namespace GraphQL.Conventions.Web
 {
     public class Response
     {
+        private static DocumentWriter _writer = new DocumentWriter();
+
+        private string _body;
+
         public Response(
             Request request,
             ExecutionResult result)
@@ -29,7 +35,27 @@ namespace GraphQL.Conventions.Web
 
         public Validation.IValidationResult ValidationResult { get; private set; }
 
-        public string Body { get; internal set; }
+        public string Body
+        {
+            get
+            {
+                if (string.IsNullOrWhiteSpace(_body) && ExecutionResult != null)
+                {
+                    _body = _writer.Write(ExecutionResult);
+                }
+                return _body;
+            }
+            internal set
+            {
+                _body = value;
+            }
+        }
+
+        public void AddExtra(string key, object value)
+        {
+            ExecutionResult.Extra[key] = value;
+            _body = null;
+        }
 
         public bool HasData => ExecutionResult?.Data != null;
 

--- a/src/GraphQL.Conventions/project.json
+++ b/src/GraphQL.Conventions/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.4-*",
+  "version": "1.3.5-*",
   "description": "GraphQL Conventions for .NET",
   "authors": [
     "Tommy Lillehagen"

--- a/test/Tests/Adapters/Engine/GraphQLExecutorTests.cs
+++ b/test/Tests/Adapters/Engine/GraphQLExecutorTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using GraphQL.Conventions.Tests.Templates;
 using GraphQL.Conventions.Tests.Templates.Extensions;
 

--- a/test/Tests/Web/RequestTests.cs
+++ b/test/Tests/Web/RequestTests.cs
@@ -45,7 +45,7 @@ namespace GraphQL.Conventions.Tests.Web
         public void Cannot_Derive_Query_From_Invalid_String()
         {
             var request = Request.New("{\"invalid_query\":\"{}\"}");
-            request.IsValid.ShouldEqual(true);
+            request.IsValid.ShouldEqual(false);
             request.QueryString.ShouldEqual(string.Empty);
         }
     }

--- a/test/Tests/Web/ResponseTests.cs
+++ b/test/Tests/Web/ResponseTests.cs
@@ -3,6 +3,7 @@ using GraphQL.Conventions.Tests.Templates;
 using GraphQL.Conventions.Tests.Templates.Extensions;
 using GraphQL.Conventions.Web;
 using GraphQL.Validation;
+using Newtonsoft.Json;
 
 namespace GraphQL.Conventions.Tests.Web
 {
@@ -27,6 +28,26 @@ namespace GraphQL.Conventions.Tests.Web
             result.Errors.Add(new ExecutionError("Test"));
             var response = new Response(request, result);
             response.ValidationResult.Errors.Count.ShouldEqual(1);
+        }
+
+        [Test]
+        public void Can_Instantiate_Response_Object_With_Extra_Data()
+        {
+            var request = Request.New("{\"query\":\"{}\"}");
+            var result = new ExecutionResult();
+            result.Data = new Dictionary<string, object>();
+            result.Extra["trace"] = new
+            {
+                foo = 1,
+                bar = new
+                {
+                    baz = "hello",
+                },
+            };
+            var response = new Response(request, result);
+            response.HasData.ShouldEqual(true);
+            response.HasErrors.ShouldEqual(false);
+            response.Body.ShouldEqual("{\"data\":{},\"extra\":{\"trace\":{\"foo\":1,\"bar\":{\"baz\":\"hello\"}}}}");
         }
     }
 }


### PR DESCRIPTION
* Set `Response.IsValid` to `false` if query string is empty
* Add `extra` field on response, allowing plugins and extensions to enrich the output
* Add `ChaosAttribute` for intentionally failing a set percentage of field resolvers at random (for testing)
* Add `NameNormalizerAttribute` to strip `Dto` suffices from type names
* Add `Response.EnrichWithProfilingInformation()` to append profiling information to the response (use in conjunction with `RequestHandlerBuilder.WithProfiling()`