### PR TITLE
Very small tidy up tests + update xunit

### DIFF
--- a/test/Tests/Adapters/ArgumentResolutionTests.cs
+++ b/test/Tests/Adapters/ArgumentResolutionTests.cs
@@ -10,7 +10,7 @@ namespace GraphQL.Conventions.Tests.Adapters
     public class ArgumentResolutionTests : TestBase
     {
         [Test]
-        public async void Can_Resolve_Argument_Using_Dependency_Injection()
+        public async Task Can_Resolve_Argument_Using_Dependency_Injection()
         {
             var result = await ExecuteQuery(@"{ dependencyInjectionField }");
             result.ShouldHaveNoErrors();
@@ -18,7 +18,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Value_Type_Argument()
+        public async Task Can_Resolve_Value_Type_Argument()
         {
             var result = await ExecuteQuery(
                 @"{ valueTypeField(valueTypeArg: 123) }");
@@ -33,7 +33,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Nullable_Value_Type_Argument()
+        public async Task Can_Resolve_Nullable_Value_Type_Argument()
         {
             var result = await ExecuteQuery(
                 @"{ nullableValueTypeField(nullableValueTypeArg: 123) }");
@@ -59,7 +59,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Nullable_Primitive_Argument()
+        public async Task Can_Resolve_Nullable_Primitive_Argument()
         {
             var result = await ExecuteQuery(
                 @"{ nullablePrimitiveField(nullablePrimitiveArg: ""Foo"") }");
@@ -74,7 +74,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_NonNullable_Primitive_Argument()
+        public async Task Can_Resolve_NonNullable_Primitive_Argument()
         {
             var result = await ExecuteQuery(
                 @"{ nonNullablePrimitiveField(nonNullablePrimitiveArg: ""Foo"") }");
@@ -89,7 +89,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Nullable_Identifier_Argument()
+        public async Task Can_Resolve_Nullable_Identifier_Argument()
         {
             var id = Id.New<Dependency>("12345");
             var result = await ExecuteQuery(
@@ -105,7 +105,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_NonNullable_Identifier_Argument()
+        public async Task Can_Resolve_NonNullable_Identifier_Argument()
         {
             var id = Id.New<Dependency>("12345");
             var result = await ExecuteQuery(
@@ -121,7 +121,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Nullable_Argument_With_Default_Value()
+        public async Task Can_Resolve_Nullable_Argument_With_Default_Value()
         {
             var result = await ExecuteQuery(
                 @"{ defaultNullableArgumentValueField(arg: 123) }");
@@ -147,7 +147,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_NonNullable_Argument_With_Default_Value()
+        public async Task Can_Resolve_NonNullable_Argument_With_Default_Value()
         {
             var result = await ExecuteQuery(
                 @"{ defaultNonNullableArgumentValueField(arg: 123) }");
@@ -162,7 +162,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Nullable_Enum_Argument()
+        public async Task Can_Resolve_Nullable_Enum_Argument()
         {
             var result = await ExecuteQuery(
                 @"{ enumField: nullableEnumField }");
@@ -199,7 +199,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_NonNullable_Enum_Argument()
+        public async Task Can_Resolve_NonNullable_Enum_Argument()
         {
             var result = await ExecuteQuery(
                 @"{ enumField: nonNullableEnumField(enumArg: FOO) }");
@@ -225,7 +225,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_List_Of_Nullable_Enums_Argument()
+        public async Task Can_Resolve_List_Of_Nullable_Enums_Argument()
         {
             var result = await ExecuteQuery(
                 @"{ listOfNullableEnumsField(arg: [BAZ, FOO]) }");
@@ -240,7 +240,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_List_Of_NonNullable_Enums_Argument()
+        public async Task Can_Resolve_List_Of_NonNullable_Enums_Argument()
         {
             var result = await ExecuteQuery(
                 @"{ listOfNonNullableEnumsField(arg: [BAZ, FOO]) }");
@@ -255,7 +255,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Nullable_InputObject_Argument()
+        public async Task Can_Resolve_Nullable_InputObject_Argument()
         {
             var result = await ExecuteQuery(
                 @"{ result: nullableInputObjectField }");
@@ -286,7 +286,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_NonNullable_InputObject_Argument()
+        public async Task Can_Resolve_NonNullable_InputObject_Argument()
         {
             var result = await ExecuteQuery(
                 @"{ result: nonNullableInputObjectField }");
@@ -316,7 +316,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Array_Of_Nullable_InputObject_Argument()
+        public async Task Can_Resolve_Array_Of_Nullable_InputObject_Argument()
         {
             var result = await ExecuteQuery(
                 @"{ result: arrayOfNullableInputObjectsField(arg: [
@@ -358,7 +358,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Array_Of_NonNullable_InputObject_Argument()
+        public async Task Can_Resolve_Array_Of_NonNullable_InputObject_Argument()
         {
             var result = await ExecuteQuery(
                 @"{ result: arrayOfNonNullableInputObjectsField }");
@@ -403,7 +403,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_List_Of_Nullable_InputObject_Argument()
+        public async Task Can_Resolve_List_Of_Nullable_InputObject_Argument()
         {
             var result = await ExecuteQuery(
                 @"{ result: listOfNullableInputObjectsField(arg: [
@@ -445,7 +445,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_List_Of_NonNullable_InputObject_Argument()
+        public async Task Can_Resolve_List_Of_NonNullable_InputObject_Argument()
         {
             var result = await ExecuteQuery(
                 @"{ result: listOfNonNullableInputObjectsField }");
@@ -490,7 +490,7 @@ namespace GraphQL.Conventions.Tests.Adapters
        }
 
         [Test]
-        public async void Can_Resolve_Enumerable_Of_Nullable_InputObject_Argument()
+        public async Task Can_Resolve_Enumerable_Of_Nullable_InputObject_Argument()
         {
             var result = await ExecuteQuery(
                 @"{ result: enumerableOfNullableInputObjectsField(arg: [
@@ -532,7 +532,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Enumerable_Of_NonNullable_InputObject_Argument()
+        public async Task Can_Resolve_Enumerable_Of_NonNullable_InputObject_Argument()
         {
             var result = await ExecuteQuery(
                 @"{ result: enumerableOfNonNullableInputObjectsField }");
@@ -577,7 +577,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Complex_Input_Object()
+        public async Task Can_Resolve_Complex_Input_Object()
         {
             var result = await ExecuteQuery(
                 @"{ result: complexInputObjectField }");
@@ -635,7 +635,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Resolution_Context_Argument()
+        public async Task Can_Resolve_Resolution_Context_Argument()
         {
             var result = await ExecuteQuery(
                 @"{ contextField }",

--- a/test/Tests/Adapters/Engine/AbstractTypeConstructionTests.cs
+++ b/test/Tests/Adapters/Engine/AbstractTypeConstructionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using GraphQL.Conventions.Tests.Templates;
 using GraphQL.Conventions.Tests.Templates.Extensions;
 
@@ -20,7 +21,7 @@ namespace GraphQL.Conventions.Tests.Adapters.Engine
         }
 
         [Test]
-        public async void Can_Execute_Query_On_Schema_From_Abstract_Types()
+        public async Task Can_Execute_Query_On_Schema_From_Abstract_Types()
         {
             var engine = GraphQLEngine.New<Query>();
             var result = await engine

--- a/test/Tests/Adapters/Engine/Bugs/Bug73NullableInputListTests.cs
+++ b/test/Tests/Adapters/Engine/Bugs/Bug73NullableInputListTests.cs
@@ -12,7 +12,7 @@ namespace GraphQL.Conventions.Tests.Adapters.Engine.Bugs
     public class Bug73NullableInputListTests : TestBase
     {
         [Test]
-        public async void Can_Accept_Null_List_From_Literal()
+        public async Task Can_Accept_Null_List_From_Literal()
         {
             var engine = GraphQLEngine
                 .New<TestQuery>();
@@ -25,7 +25,7 @@ namespace GraphQL.Conventions.Tests.Adapters.Engine.Bugs
         }
 
         [Test]
-        public async void Can_Accept_Null_List_From_Input()
+        public async Task Can_Accept_Null_List_From_Input()
         {
             var engine = GraphQLEngine
                 .New<TestQuery>();

--- a/test/Tests/Adapters/Engine/DependencyInjectionTests.cs
+++ b/test/Tests/Adapters/Engine/DependencyInjectionTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Threading.Tasks;
 using GraphQL.Conventions.Tests.Templates;
 using GraphQL.Conventions.Tests.Templates.Extensions;
 
@@ -19,7 +20,7 @@ namespace GraphQL.Conventions.Tests.Adapters.Engine
         }
 
         [Test]
-        public async void Can_Execute_Query_On_Schema_With_Injections()
+        public async Task Can_Execute_Query_On_Schema_With_Injections()
         {
             var engine = GraphQLEngine.New<Query>();
             var result = await engine
@@ -33,7 +34,7 @@ namespace GraphQL.Conventions.Tests.Adapters.Engine
         }
 
         [Test]
-        public async void Each_Executor_Should_Use_Its_Own_Injector()
+        public async Task Each_Executor_Should_Use_Its_Own_Injector()
         {
             var engine = GraphQLEngine.New<Query>();
 
@@ -73,7 +74,7 @@ namespace GraphQL.Conventions.Tests.Adapters.Engine
         }
 
         [Test]
-        public async void Can_Execute_Query_On_Schema_With_Injections_In_Generic_Methods()
+        public async Task Can_Execute_Query_On_Schema_With_Injections_In_Generic_Methods()
         {
             var engine = GraphQLEngine.New<QueryWithDIFields>();
             var result = await engine

--- a/test/Tests/Adapters/Engine/DynamicConstructionTests.cs
+++ b/test/Tests/Adapters/Engine/DynamicConstructionTests.cs
@@ -35,23 +35,6 @@ namespace GraphQL.Conventions.Tests.Adapters.Engine
                 Resolver = new CustomResolver(new UserRepository()),
             });
 
-            schema.ResolveType = (t) =>
-            {
-                if (t == typeof(IUserRepository))
-                {
-                    return userRepositoryInterface;
-                }
-                if (t == typeof(UserRepository))
-                {
-                    return userRepositoryType;
-                }
-                if (t == typeof(User))
-                {
-                    return userType;
-                }
-                return null;
-            };
-
             var schemaDescription = new SchemaPrinter(schema).Print();
             schemaDescription.ShouldEqualWhenReformatted(@"
             interface IUserRepository {

--- a/test/Tests/Adapters/Engine/DynamicConstructionTests.cs
+++ b/test/Tests/Adapters/Engine/DynamicConstructionTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Threading.Tasks;
 using GraphQL.Conventions.Adapters;
 using GraphQL.Conventions.Tests.Templates;
 using GraphQL.Conventions.Tests.Templates.Extensions;
@@ -12,7 +13,7 @@ namespace GraphQL.Conventions.Tests.Adapters.Engine
     public class DynamicConstructionTests : TestBase
     {
         [Test]
-        public async void Can_Construct_And_Describe_Schema_With_Dynamic_Queries()
+        public async Task Can_Construct_And_Describe_Schema_With_Dynamic_Queries()
         {
             var typeAdapter = new GraphTypeAdapter();
             var typeResolver = new TypeResolver();

--- a/test/Tests/Adapters/Engine/ErrorTests.cs
+++ b/test/Tests/Adapters/Engine/ErrorTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using GraphQL.Conventions.Tests.Templates;
 using GraphQL.Conventions.Tests.Templates.Extensions;
 
@@ -9,7 +10,7 @@ namespace GraphQL.Conventions.Tests.Adapters.Engine
     public class ErrorTests : TestBase
     {
         [Test]
-        public async void Will_Provide_Path_And_Code_For_Errors_On_Fields_With_Operation_Name()
+        public async Task Will_Provide_Path_And_Code_For_Errors_On_Fields_With_Operation_Name()
         {
             var engine = GraphQLEngine.New<Query>();
             var result = await engine
@@ -18,7 +19,7 @@ namespace GraphQL.Conventions.Tests.Adapters.Engine
                 .Execute();
 
             result.Errors.ShouldNotBeNull();
-            result.Errors.Count().ShouldEqual(1);
+            result.Errors.Count.ShouldEqual(1);
             var error = result.Errors.First();
             error.Message.ShouldEqual("Test error.");
             error.Code.ShouldEqual("ARGUMENT");
@@ -29,7 +30,7 @@ namespace GraphQL.Conventions.Tests.Adapters.Engine
         }
 
         [Test]
-        public async void Will_Provide_Path_And_Code_For_Errors_On_Fields_Without_Operation_Name()
+        public async Task Will_Provide_Path_And_Code_For_Errors_On_Fields_Without_Operation_Name()
         {
             var engine = GraphQLEngine.New<Query>();
             var result = await engine
@@ -38,7 +39,7 @@ namespace GraphQL.Conventions.Tests.Adapters.Engine
                 .Execute();
 
             result.Errors.ShouldNotBeNull();
-            result.Errors.Count().ShouldEqual(1);
+            result.Errors.Count.ShouldEqual(1);
             var error = result.Errors.First();
             error.Message.ShouldEqual("Test error.");
             error.Code.ShouldEqual("ARGUMENT");
@@ -49,7 +50,7 @@ namespace GraphQL.Conventions.Tests.Adapters.Engine
         }
 
         [Test]
-        public async void Will_Provide_Path_And_Code_For_Errors_On_Fields_With_Aliases()
+        public async Task Will_Provide_Path_And_Code_For_Errors_On_Fields_With_Aliases()
         {
             var engine = GraphQLEngine.New<Query>();
             var result = await engine
@@ -58,7 +59,7 @@ namespace GraphQL.Conventions.Tests.Adapters.Engine
                 .Execute();
 
             result.Errors.ShouldNotBeNull();
-            result.Errors.Count().ShouldEqual(1);
+            result.Errors.Count.ShouldEqual(1);
             var error = result.Errors.First();
             error.Message.ShouldEqual("Test error.");
             error.Code.ShouldEqual("ARGUMENT");
@@ -69,7 +70,7 @@ namespace GraphQL.Conventions.Tests.Adapters.Engine
         }
 
         [Test]
-        public async void Will_Provide_Path_And_Code_For_Errors_In_Array_Fields()
+        public async Task Will_Provide_Path_And_Code_For_Errors_In_Array_Fields()
         {
             var engine = GraphQLEngine.New<Query>();
             var result = await engine
@@ -83,7 +84,7 @@ namespace GraphQL.Conventions.Tests.Adapters.Engine
             result.Data.ShouldHaveFieldWithValue("getObject", "arrayField", 3, "test", null);
 
             result.Errors.ShouldNotBeNull();
-            result.Errors.Count().ShouldEqual(2);
+            result.Errors.Count.ShouldEqual(2);
 
             var error = result.Errors.ElementAt(0);
             error.Message.ShouldEqual("Test error.");
@@ -105,7 +106,7 @@ namespace GraphQL.Conventions.Tests.Adapters.Engine
         }
 
         [Test]
-        public async void Will_Provide_Exception_Data()
+        public async Task Will_Provide_Exception_Data()
         {
             var engine = GraphQLEngine.New<Query>();
             var result = await engine
@@ -116,7 +117,7 @@ namespace GraphQL.Conventions.Tests.Adapters.Engine
             result.Data.ShouldHaveFieldWithValue("errorWithData", null);
 
             result.Errors.ShouldNotBeNull();
-            result.Errors.Count().ShouldEqual(1);
+            result.Errors.Count.ShouldEqual(1);
 
             result.Errors.First().Message.ShouldEqual("Test error.");
             result.Errors.First().Data["someKey"].ShouldEqual("someValue");

--- a/test/Tests/Adapters/Engine/GenericTypesInInterfaceTests.cs
+++ b/test/Tests/Adapters/Engine/GenericTypesInInterfaceTests.cs
@@ -1,5 +1,6 @@
 using GraphQL.Conventions.Tests.Templates;
 using GraphQL.Conventions.Tests.Templates.Extensions;
+using System.Threading.Tasks;
 
 namespace GraphQL.Conventions.Tests.Adapters.Engine
 {
@@ -24,7 +25,7 @@ namespace GraphQL.Conventions.Tests.Adapters.Engine
         }
 
         [Test]
-        public async void Can_Execute_Query_On_Schema_Using_Interfaces_With_Generic_Types()
+        public async Task Can_Execute_Query_On_Schema_Using_Interfaces_With_Generic_Types()
         {
             var engine = GraphQLEngine.New<Query>();
             var result = await engine

--- a/test/Tests/Adapters/Engine/GraphQLEngineTests.cs
+++ b/test/Tests/Adapters/Engine/GraphQLEngineTests.cs
@@ -165,7 +165,7 @@ namespace GraphQL.Conventions.Tests.Adapters.Engine
         }
 
         [Test]
-        public async void Can_Register_And_Use_Custom_Scalar_Types()
+        public async Task Can_Register_And_Use_Custom_Scalar_Types()
         {
             var engine = GraphQLEngine
                 .New()

--- a/test/Tests/Adapters/FieldResolutionTests.cs
+++ b/test/Tests/Adapters/FieldResolutionTests.cs
@@ -17,6 +17,7 @@ namespace GraphQL.Conventions.Tests.Adapters
             result.Data.ShouldHaveFieldWithValue("nonNullBooleanField", true);
         }
 
+        [Test]
         public async void Can_Resolve_Nullable_Field()
         {
             var result = await ExecuteQuery("{ booleanField }");
@@ -48,6 +49,7 @@ namespace GraphQL.Conventions.Tests.Adapters
             result.Data.ShouldHaveFieldWithValue("nonNullEnumField", "TWO");
         }
 
+        [Test]
         public async void Can_Resolve_Nullable_Enum_Field()
         {
             var result = await ExecuteQuery("{ enumField }");
@@ -79,6 +81,7 @@ namespace GraphQL.Conventions.Tests.Adapters
             result.Data.ShouldHaveFieldWithValue("nonNullIdField", Id.New<SimpleObject>("54321").ToString());
         }
 
+        [Test]
         public async void Can_Resolve_Nullable_Id_Field()
         {
             var result = await ExecuteQuery("{ idField }");

--- a/test/Tests/Adapters/FieldResolutionTests.cs
+++ b/test/Tests/Adapters/FieldResolutionTests.cs
@@ -10,7 +10,7 @@ namespace GraphQL.Conventions.Tests.Adapters
     public class FieldResolutionTests : TestBase
     {
         [Test]
-        public async void Can_Resolve_NonNullable_Field()
+        public async Task Can_Resolve_NonNullable_Field()
         {
             var result = await ExecuteQuery("{ nonNullBooleanField }");
             result.ShouldHaveNoErrors();
@@ -18,7 +18,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Nullable_Field()
+        public async Task Can_Resolve_Nullable_Field()
         {
             var result = await ExecuteQuery("{ booleanField }");
             result.ShouldHaveNoErrors();
@@ -26,7 +26,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_NonNullable_Task_Field()
+        public async Task Can_Resolve_NonNullable_Task_Field()
         {
             var result = await ExecuteQuery("{ nonNullBooleanTaskField }");
             result.ShouldHaveNoErrors();
@@ -34,7 +34,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Nullable_Task_Field()
+        public async Task Can_Resolve_Nullable_Task_Field()
         {
             var result = await ExecuteQuery("{ booleanTaskField }");
             result.ShouldHaveNoErrors();
@@ -42,7 +42,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_NonNullable_Enum_Field()
+        public async Task Can_Resolve_NonNullable_Enum_Field()
         {
             var result = await ExecuteQuery("{ nonNullEnumField }");
             result.ShouldHaveNoErrors();
@@ -50,7 +50,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Nullable_Enum_Field()
+        public async Task Can_Resolve_Nullable_Enum_Field()
         {
             var result = await ExecuteQuery("{ enumField }");
             result.ShouldHaveNoErrors();
@@ -58,7 +58,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_NonNullable_Enum_Task_Field()
+        public async Task Can_Resolve_NonNullable_Enum_Task_Field()
         {
             var result = await ExecuteQuery("{ nonNullEnumTaskField }");
             result.ShouldHaveNoErrors();
@@ -66,7 +66,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Nullable_Enum_Task_Field()
+        public async Task Can_Resolve_Nullable_Enum_Task_Field()
         {
             var result = await ExecuteQuery("{ enumTaskField }");
             result.ShouldHaveNoErrors();
@@ -74,7 +74,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_NonNullable_Id_Field()
+        public async Task Can_Resolve_NonNullable_Id_Field()
         {
             var result = await ExecuteQuery("{ nonNullIdField }");
             result.ShouldHaveNoErrors();
@@ -82,7 +82,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Nullable_Id_Field()
+        public async Task Can_Resolve_Nullable_Id_Field()
         {
             var result = await ExecuteQuery("{ idField }");
             result.ShouldHaveNoErrors();
@@ -90,7 +90,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_NonNullable_Id_Task_Field()
+        public async Task Can_Resolve_NonNullable_Id_Task_Field()
         {
             var result = await ExecuteQuery("{ nonNullIdTaskField }");
             result.ShouldHaveNoErrors();
@@ -98,7 +98,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Nullable_Id_Task_Field()
+        public async Task Can_Resolve_Nullable_Id_Task_Field()
         {
             var result = await ExecuteQuery("{ idTaskField }");
             result.ShouldHaveNoErrors();
@@ -106,7 +106,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Url_Field()
+        public async Task Can_Resolve_Url_Field()
         {
             var result = await ExecuteQuery("{ urlField }");
             result.ShouldHaveNoErrors();
@@ -114,7 +114,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_List_Of_Nullable_Primitives_Field()
+        public async Task Can_Resolve_List_Of_Nullable_Primitives_Field()
         {
             var result = await ExecuteQuery("{ list: nullablePrimitiveListField }");
             result.ShouldHaveNoErrors();
@@ -125,7 +125,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_List_Of_Primitives_Field()
+        public async Task Can_Resolve_List_Of_Primitives_Field()
         {
             var result = await ExecuteQuery("{ list: primitiveListField }");
             result.ShouldHaveNoErrors();
@@ -136,7 +136,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_List_Of_Nullables_Field()
+        public async Task Can_Resolve_List_Of_Nullables_Field()
         {
             var result = await ExecuteQuery("{ list: listField }");
             result.ShouldHaveNoErrors();
@@ -147,7 +147,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_List_Of_NonNullables_Field()
+        public async Task Can_Resolve_List_Of_NonNullables_Field()
         {
             var result = await ExecuteQuery("{ list: listOfNonNullField }");
             result.ShouldHaveNoErrors();
@@ -158,7 +158,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_NonNullable_List_Of_Nullables_Field()
+        public async Task Can_Resolve_NonNullable_List_Of_Nullables_Field()
         {
             var result = await ExecuteQuery("{ list: nonNullListField }");
             result.ShouldHaveNoErrors();
@@ -169,7 +169,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_NonNullable_List_Of_NonNullables_Field()
+        public async Task Can_Resolve_NonNullable_List_Of_NonNullables_Field()
         {
             var result = await ExecuteQuery("{ list: nonNullListOfNonNullField }");
             result.ShouldHaveNoErrors();
@@ -180,7 +180,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_NonNullable_List_Of_NonNullable_URLs_Field()
+        public async Task Can_Resolve_NonNullable_List_Of_NonNullable_URLs_Field()
         {
             var result = await ExecuteQuery("{ urls: nonNullListOfNonNullUrlsField }");
             result.ShouldHaveNoErrors();
@@ -190,7 +190,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_NonNullable_List_Of_NonNullable_URLs_Task_Field()
+        public async Task Can_Resolve_NonNullable_List_Of_NonNullable_URLs_Task_Field()
         {
             var result = await ExecuteQuery("{ urls: nonNullListOfNonNullUrlsTaskField }");
             result.ShouldHaveNoErrors();
@@ -200,7 +200,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Enumerable_Field()
+        public async Task Can_Resolve_Enumerable_Field()
         {
             var result = await ExecuteQuery("{ enumerableField iListField arrayField }");
             result.ShouldHaveNoErrors();
@@ -222,7 +222,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Enumerable_Of_NonNullable_URLs_Field()
+        public async Task Can_Resolve_Enumerable_Of_NonNullable_URLs_Field()
         {
             var result = await ExecuteQuery("{ urls: enumerableOfNonNullUrlsField }");
             result.ShouldHaveNoErrors();
@@ -232,7 +232,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Throws_Exception_With_Correct_StackTrace_On_Error()
+        public async Task Throws_Exception_With_Correct_StackTrace_On_Error()
         {
             var result = await ExecuteQuery("{ errorField }");
             result.ShouldHaveErrors(1);
@@ -242,7 +242,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Throws_Exception_With_Correct_StackTrace_On_Task_Error()
+        public async Task Throws_Exception_With_Correct_StackTrace_On_Task_Error()
         {
             var result = await ExecuteQuery("{ errorTaskField }");
             result.ShouldHaveErrors(1);
@@ -252,7 +252,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_NonNullable_Object_Field()
+        public async Task Can_Resolve_NonNullable_Object_Field()
         {
             var result = await ExecuteQuery(@"
             {
@@ -264,7 +264,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Nullable_Object_Field()
+        public async Task Can_Resolve_Nullable_Object_Field()
         {
             var result = await ExecuteQuery(@"
             {
@@ -276,7 +276,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_NonNullable_Object_Task_Field()
+        public async Task Can_Resolve_NonNullable_Object_Task_Field()
         {
             var result = await ExecuteQuery(@"
             {
@@ -288,7 +288,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Nullable_Object_Task_Field()
+        public async Task Can_Resolve_Nullable_Object_Task_Field()
         {
             var result = await ExecuteQuery(@"
             {
@@ -300,7 +300,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Interface_Field()
+        public async Task Can_Resolve_Interface_Field()
         {
             var result = await ExecuteQuery(@"
             {
@@ -336,7 +336,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Union_Field()
+        public async Task Can_Resolve_Union_Field()
         {
             var result = await ExecuteQuery(@"
             {
@@ -366,7 +366,7 @@ namespace GraphQL.Conventions.Tests.Adapters
         }
 
         [Test]
-        public async void Can_Resolve_Asynchronous_Field()
+        public async Task Can_Resolve_Asynchronous_Field()
         {
             var result = await ExecuteQuery(@"
             {

--- a/test/Tests/Attributes/Execution/Relay/DynamicMutationRegistrationTests.cs
+++ b/test/Tests/Attributes/Execution/Relay/DynamicMutationRegistrationTests.cs
@@ -9,7 +9,7 @@ namespace GraphQL.Conventions.Tests.Attributes.Execution.Relay
     public class DynamicMutationRegistrationTests : TestBase
     {
         [Test]
-        public async void Can_Pass_On_ClientMutationId_For_Relay_Nullable_Mutations()
+        public async Task Can_Pass_On_ClientMutationId_For_Relay_Nullable_Mutations()
         {
             var query = @"
                 mutation _ {

--- a/test/Tests/Attributes/Execution/Relay/RelayMutationAttributeTests.cs
+++ b/test/Tests/Attributes/Execution/Relay/RelayMutationAttributeTests.cs
@@ -9,7 +9,7 @@ namespace GraphQL.Conventions.Tests.Attributes.Execution.Relay
     public class RelayMutationAttributeTests : TestBase
     {
         [Test]
-        public async void Can_Pass_On_ClientMutationId_For_Relay_Nullable_Mutations()
+        public async Task Can_Pass_On_ClientMutationId_For_Relay_Nullable_Mutations()
         {
             var result = await ExecuteMutation(@"
                 mutation _ {
@@ -24,7 +24,7 @@ namespace GraphQL.Conventions.Tests.Attributes.Execution.Relay
         }
 
         [Test]
-        public async void Can_Pass_On_ClientMutationId_For_Relay_NonNullable_Mutations()
+        public async Task Can_Pass_On_ClientMutationId_For_Relay_NonNullable_Mutations()
         {
             var result = await ExecuteMutation(@"
                 mutation _ {
@@ -39,7 +39,7 @@ namespace GraphQL.Conventions.Tests.Attributes.Execution.Relay
         }
 
         [Test]
-        public async void Can_Pass_On_ClientMutationId_For_Relay_Task_Mutations()
+        public async Task Can_Pass_On_ClientMutationId_For_Relay_Task_Mutations()
         {
             var result = await ExecuteMutation(@"
                 mutation _ {
@@ -54,7 +54,7 @@ namespace GraphQL.Conventions.Tests.Attributes.Execution.Relay
         }
 
         [Test]
-        public async void Can_Pass_On_ClientMutationId_For_Relay_Nullable_Mutations_With_Type_Decoration()
+        public async Task Can_Pass_On_ClientMutationId_For_Relay_Nullable_Mutations_With_Type_Decoration()
         {
             var result = await ExecuteMutation<MutationType>(@"
                 mutation _ {
@@ -69,7 +69,7 @@ namespace GraphQL.Conventions.Tests.Attributes.Execution.Relay
         }
 
         [Test]
-        public async void Can_Pass_On_ClientMutationId_For_Relay_NonNullable_Mutations_With_Type_Decoration()
+        public async Task Can_Pass_On_ClientMutationId_For_Relay_NonNullable_Mutations_With_Type_Decoration()
         {
             var result = await ExecuteMutation<MutationType>(@"
                 mutation _ {
@@ -84,7 +84,7 @@ namespace GraphQL.Conventions.Tests.Attributes.Execution.Relay
         }
 
         [Test]
-        public async void Can_Pass_On_ClientMutationId_For_Relay_Task_Mutations_With_Type_Decoration()
+        public async Task Can_Pass_On_ClientMutationId_For_Relay_Task_Mutations_With_Type_Decoration()
         {
             var result = await ExecuteMutation<MutationType>(@"
                 mutation _ {

--- a/test/Tests/Attributes/MetaData/Relay/ImplementViewerAttributeTests.cs
+++ b/test/Tests/Attributes/MetaData/Relay/ImplementViewerAttributeTests.cs
@@ -25,7 +25,7 @@ namespace GraphQL.Conventions.Tests.Attributes.MetaData.Relay
         }
 
         [Test]
-        public async void Can_Use_The_Viewer_Node_For_A_Schema()
+        public async Task Can_Use_The_Viewer_Node_For_A_Schema()
         {
             var result = await ExecuteQuery(false, @"
             {
@@ -56,7 +56,7 @@ namespace GraphQL.Conventions.Tests.Attributes.MetaData.Relay
         }
 
         [Test]
-        public async void Can_Use_The_Viewer_Node_For_Multiple_Schemas()
+        public async Task Can_Use_The_Viewer_Node_For_Multiple_Schemas()
         {
             var result = await ExecuteQuery(true, @"
             {

--- a/test/Tests/Tests.csproj
+++ b/test/Tests/Tests.csproj
@@ -12,9 +12,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.reporters" Version="2.3.0-beta1-build3642" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.reporters" Version="2.3.1" />
     <PackageReference Include="Shouldly" Version="2.8.2" />
     <PackageReference Include="NSubstitute" Version="2.0.0-*" />
     <PackageReference Include="ReportGenerator" Version="2.5.9" />

--- a/test/Tests/Web/RequestHandlerTests.cs
+++ b/test/Tests/Web/RequestHandlerTests.cs
@@ -43,7 +43,7 @@ namespace GraphQL.Conventions.Tests.Web
         }
 
         [Test]
-        public async void Cannot_Run_Too_Complex_Query_Using_ComplexityConfiguration()
+        public async Task Cannot_Run_Too_Complex_Query_Using_ComplexityConfiguration()
         {
             var request = Request.New("{ \"query\": \"{ sub { sub { end } } }\" }");
             var response = await RequestHandler
@@ -58,7 +58,7 @@ namespace GraphQL.Conventions.Tests.Web
         }
 
         [Test]
-        public async void Can_Enrich_With_Profiling_Information()
+        public async Task Can_Enrich_With_Profiling_Information()
         {
             var request = Request.New("{ \"query\": \"{ a: foo(ms: 10) b: foo(ms: 20) }\" }");
             var response = await RequestHandler
@@ -72,7 +72,7 @@ namespace GraphQL.Conventions.Tests.Web
         }
 
         [Test]
-        public async void Can_Ignore_Types_From_Unwanted_Namespaces()
+        public async Task Can_Ignore_Types_From_Unwanted_Namespaces()
         {
             // Include all types from CompositeQuery
             var request = Request.New("{ \"query\": \"{ earth { hello } mars { hello } } \" }");


### PR DESCRIPTION
## Description
Tidy up a few things

* Add `[Test]` that were missing
* Bump xunit version so it can run tests on VS2017
* Removes deprecated call to `ResolveType`
* Replaces `void` with `Task` for async tests