### PR TITLE
200 response for errors

### DIFF
--- a/samples/SimpleWebApp/Startup.cs
+++ b/samples/SimpleWebApp/Startup.cs
@@ -56,7 +56,7 @@ namespace GraphQL.Conventions.Tests.Server
             var result = await _requestHandler
                 .ProcessRequest(Request.New(body), userContext);
             context.Response.Headers.Add("Content-Type", "application/json; charset=utf-8");
-            context.Response.StatusCode = result.Errors?.Count > 0 ? 400 : 200;
+            context.Response.StatusCode = 200;
             await context.Response.WriteAsync(result.Body);
         }
     }


### PR DESCRIPTION
Per the GraphQL spec, errors should exposed via the JSON payload instead of HTTP status codes. This enables expected behavior in some clients that expect a 200, e.g. in GraphiQL, the error response is only pretty-printed / syntax highlighted if the status code is 200.