### PR TITLE
Update GraphQL library reference

### DIFF
--- a/src/GraphQL.Conventions/CommonAssemblyInfo.cs
+++ b/src/GraphQL.Conventions/CommonAssemblyInfo.cs
@@ -8,8 +8,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright("Copyright 2016-2017 Tommy Lillehagen. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.4.0")]
-[assembly: AssemblyInformationalVersion("1.4.0")]
+[assembly: AssemblyFileVersion("1.5.0")]
+[assembly: AssemblyInformationalVersion("1.5.0")]
 [assembly: CLSCompliant(false)]
 
 [assembly: InternalsVisibleTo("Tests")]

--- a/src/GraphQL.Conventions/Extensions/Profiling/ProfilingResultEnricher.cs
+++ b/src/GraphQL.Conventions/Extensions/Profiling/ProfilingResultEnricher.cs
@@ -19,7 +19,7 @@ namespace GraphQL.Conventions.Extensions
 
                 records.Add(new PerformanceRecord
                 {
-                    Path = record.Metadata.ContainsKey("path") ? string.Join(".", record.Metadata["path"] as List<string>) : null,
+                    Path = record.Metadata.ContainsKey("path") ? string.Join(".", record.Metadata["path"] as string[]) : null,
                     StartTimeInMs = (long)record.Start,
                     EndTimeInMs = (long)record.End,
                     ParentType = GetOrDefault<string>(record.Metadata, "typeName", null),

--- a/src/GraphQL.Conventions/GraphQL.Conventions.csproj
+++ b/src/GraphQL.Conventions/GraphQL.Conventions.csproj
@@ -38,7 +38,7 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="GraphQL" Version="2.0.0-alpha-887" />
+    <PackageReference Include="GraphQL" Version="2.1.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/GraphQL.Conventions/GraphQL.Conventions.csproj
+++ b/src/GraphQL.Conventions/GraphQL.Conventions.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
     <Description>GraphQL Conventions for .NET</Description>
-    <VersionPrefix>1.4.0</VersionPrefix>
+    <VersionPrefix>1.5.0</VersionPrefix>
     <Authors>Tommy Lillehagen</Authors>
     <TargetFrameworks>netstandard1.6.1;net45</TargetFrameworks>
     <DebugType>portable</DebugType>
@@ -31,7 +31,7 @@
     <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="GraphQL" Version="2.0.0-alpha-887" />
+    <PackageReference Include="GraphQL" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/test/Tests/Adapters/Engine/AbstractTypeConstructionTests.cs
+++ b/test/Tests/Adapters/Engine/AbstractTypeConstructionTests.cs
@@ -31,7 +31,7 @@ namespace GraphQL.Conventions.Tests.Adapters.Engine
                 .Execute();
 
             result.ShouldHaveNoErrors();
-            result.Data.ShouldHaveFieldWithValue("commonField", new DateTime(1970, 1, 1));
+            result.Data.ShouldHaveFieldWithValue("commonField", "1970-01-01");
             result.Data.ShouldHaveFieldWithValue("someOtherField", string.Empty);
         }
 

--- a/test/Tests/Adapters/TypeMappingTests.cs
+++ b/test/Tests/Adapters/TypeMappingTests.cs
@@ -34,7 +34,7 @@ namespace GraphQL.Conventions.Tests.Adapters
             Type<TimeSpan?>().ShouldBeOfType<TimeSpanGraphType>();
             Type<Id?>().ShouldBeOfType<Extended.IdGraphType>();
             Type<Url>().ShouldBeOfType<UrlGraphType>();
-            Type<Uri>().ShouldBeOfType<UriGraphType>();
+            Type<Uri>().ShouldBeOfType<ConventionsTypes.UriGraphType>();
             Type<Cursor?>().ShouldBeOfType<Extended.Relay.CursorGraphType>();
             Type<Guid?>().ShouldBeOfType<GuidGraphType>();
         }
@@ -60,7 +60,7 @@ namespace GraphQL.Conventions.Tests.Adapters
             Type<TimeSpan>().ShouldBeOfNonNullableType<TimeSpanGraphType>();
             Type<Id>().ShouldBeOfNonNullableType<Extended.IdGraphType>();
             Type<NonNull<Url>>().ShouldBeOfNonNullableType<UrlGraphType>();
-            Type<NonNull<Uri>>().ShouldBeOfNonNullableType<UriGraphType>();
+            Type<NonNull<Uri>>().ShouldBeOfNonNullableType<ConventionsTypes.UriGraphType>();
             Type<Cursor>().ShouldBeOfNonNullableType<Extended.Relay.CursorGraphType>();
             Type<Guid>().ShouldBeOfNonNullableType<GuidGraphType>();
         }
@@ -136,7 +136,7 @@ namespace GraphQL.Conventions.Tests.Adapters
             Type<List<TimeSpan?>>().ShouldBeOfListType<TimeSpanGraphType>();
             Type<List<Id?>>().ShouldBeOfListType<Extended.IdGraphType>();
             Type<List<Url>>().ShouldBeOfListType<UrlGraphType>();
-            Type<List<Uri>>().ShouldBeOfListType<UriGraphType>();
+            Type<List<Uri>>().ShouldBeOfListType<ConventionsTypes.UriGraphType>();
             Type<List<Cursor?>>().ShouldBeOfListType<Extended.Relay.CursorGraphType>();
             Type<List<Guid?>>().ShouldBeOfListType<GuidGraphType>();
         }
@@ -162,7 +162,7 @@ namespace GraphQL.Conventions.Tests.Adapters
             Type<List<TimeSpan>>().ShouldBeOfListType<NonNullGraphType<TimeSpanGraphType>>();
             Type<List<Id>>().ShouldBeOfListType<NonNullGraphType<Extended.IdGraphType>>();
             Type<List<NonNull<Url>>>().ShouldBeOfListType<NonNullGraphType<UrlGraphType>>();
-            Type<List<NonNull<Uri>>>().ShouldBeOfListType<NonNullGraphType<UriGraphType>>();
+            Type<List<NonNull<Uri>>>().ShouldBeOfListType<NonNullGraphType<ConventionsTypes.UriGraphType>>();
             Type<List<Cursor>>().ShouldBeOfListType<NonNullGraphType<Extended.Relay.CursorGraphType>>();
             Type<List<Guid>>().ShouldBeOfListType<NonNullGraphType<GuidGraphType>>();
         }
@@ -238,7 +238,7 @@ namespace GraphQL.Conventions.Tests.Adapters
             Type<NonNull<List<TimeSpan?>>>().ShouldBeOfNonNullableListType<TimeSpanGraphType>();
             Type<NonNull<List<Id?>>>().ShouldBeOfNonNullableListType<Extended.IdGraphType>();
             Type<NonNull<List<Url>>>().ShouldBeOfNonNullableListType<UrlGraphType>();
-            Type<NonNull<List<Uri>>>().ShouldBeOfNonNullableListType<UriGraphType>();
+            Type<NonNull<List<Uri>>>().ShouldBeOfNonNullableListType<ConventionsTypes.UriGraphType>();
             Type<NonNull<List<Cursor?>>>().ShouldBeOfNonNullableListType<Extended.Relay.CursorGraphType>();
             Type<NonNull<List<Guid?>>>().ShouldBeOfNonNullableListType<GuidGraphType>();
         }
@@ -264,7 +264,7 @@ namespace GraphQL.Conventions.Tests.Adapters
             Type<NonNull<List<TimeSpan>>>().ShouldBeOfNonNullableListType<NonNullGraphType<TimeSpanGraphType>>();
             Type<NonNull<List<Id>>>().ShouldBeOfNonNullableListType<NonNullGraphType<Extended.IdGraphType>>();
             Type<NonNull<List<NonNull<Url>>>>().ShouldBeOfNonNullableListType<NonNullGraphType<UrlGraphType>>();
-            Type<NonNull<List<NonNull<Uri>>>>().ShouldBeOfNonNullableListType<NonNullGraphType<UriGraphType>>();
+            Type<NonNull<List<NonNull<Uri>>>>().ShouldBeOfNonNullableListType<NonNullGraphType<ConventionsTypes.UriGraphType>>();
             Type<NonNull<List<Cursor>>>().ShouldBeOfNonNullableListType<NonNullGraphType<Extended.Relay.CursorGraphType>>();
             Type<NonNull<List<Guid>>>().ShouldBeOfNonNullableListType<NonNullGraphType<GuidGraphType>>();
         }
@@ -340,7 +340,7 @@ namespace GraphQL.Conventions.Tests.Adapters
             Type<Task<TimeSpan?>>().ShouldBeOfType<TimeSpanGraphType>();
             Type<Task<Id?>>().ShouldBeOfType<Extended.IdGraphType>();
             Type<Task<Url>>().ShouldBeOfType<UrlGraphType>();
-            Type<Task<Uri>>().ShouldBeOfType<UriGraphType>();
+            Type<Task<Uri>>().ShouldBeOfType<ConventionsTypes.UriGraphType>();
             Type<Task<Cursor?>>().ShouldBeOfType<Extended.Relay.CursorGraphType>();
             Type<Task<Guid?>>().ShouldBeOfType<GuidGraphType>();
         }
@@ -366,7 +366,7 @@ namespace GraphQL.Conventions.Tests.Adapters
             Type<Task<TimeSpan>>().ShouldBeOfNonNullableType<TimeSpanGraphType>();
             Type<Task<Id>>().ShouldBeOfNonNullableType<Extended.IdGraphType>();
             Type<Task<NonNull<Url>>>().ShouldBeOfNonNullableType<UrlGraphType>();
-            Type<Task<NonNull<Uri>>>().ShouldBeOfNonNullableType<UriGraphType>();
+            Type<Task<NonNull<Uri>>>().ShouldBeOfNonNullableType<ConventionsTypes.UriGraphType>();
             Type<Task<Cursor>>().ShouldBeOfNonNullableType<Extended.Relay.CursorGraphType>();
             Type<Task<Guid>>().ShouldBeOfNonNullableType<GuidGraphType>();
         }
@@ -442,7 +442,7 @@ namespace GraphQL.Conventions.Tests.Adapters
             Type<Task<List<TimeSpan?>>>().ShouldBeOfListType<TimeSpanGraphType>();
             Type<Task<List<Id?>>>().ShouldBeOfListType<Extended.IdGraphType>();
             Type<Task<List<Url>>>().ShouldBeOfListType<UrlGraphType>();
-            Type<Task<List<Uri>>>().ShouldBeOfListType<UriGraphType>();
+            Type<Task<List<Uri>>>().ShouldBeOfListType<ConventionsTypes.UriGraphType>();
             Type<Task<List<Cursor?>>>().ShouldBeOfListType<Extended.Relay.CursorGraphType>();
             Type<Task<List<Guid?>>>().ShouldBeOfListType<GuidGraphType>();
         }
@@ -468,7 +468,7 @@ namespace GraphQL.Conventions.Tests.Adapters
             Type<Task<List<TimeSpan>>>().ShouldBeOfListType<NonNullGraphType<TimeSpanGraphType>>();
             Type<Task<List<Id>>>().ShouldBeOfListType<NonNullGraphType<Extended.IdGraphType>>();
             Type<Task<List<NonNull<Url>>>>().ShouldBeOfListType<NonNullGraphType<UrlGraphType>>();
-            Type<Task<List<NonNull<Uri>>>>().ShouldBeOfListType<NonNullGraphType<UriGraphType>>();
+            Type<Task<List<NonNull<Uri>>>>().ShouldBeOfListType<NonNullGraphType<ConventionsTypes.UriGraphType>>();
             Type<Task<List<Cursor>>>().ShouldBeOfListType<NonNullGraphType<Extended.Relay.CursorGraphType>>();
             Type<Task<List<Guid>>>().ShouldBeOfListType<NonNullGraphType<GuidGraphType>>();
         }
@@ -544,7 +544,7 @@ namespace GraphQL.Conventions.Tests.Adapters
             Type<Task<NonNull<List<TimeSpan?>>>>().ShouldBeOfNonNullableListType<TimeSpanGraphType>();
             Type<Task<NonNull<List<Id?>>>>().ShouldBeOfNonNullableListType<Extended.IdGraphType>();
             Type<Task<NonNull<List<Url>>>>().ShouldBeOfNonNullableListType<UrlGraphType>();
-            Type<Task<NonNull<List<Uri>>>>().ShouldBeOfNonNullableListType<UriGraphType>();
+            Type<Task<NonNull<List<Uri>>>>().ShouldBeOfNonNullableListType<ConventionsTypes.UriGraphType>();
             Type<Task<NonNull<List<Cursor?>>>>().ShouldBeOfNonNullableListType<Extended.Relay.CursorGraphType>();
             Type<Task<NonNull<List<Guid?>>>>().ShouldBeOfNonNullableListType<GuidGraphType>();
         }
@@ -570,7 +570,7 @@ namespace GraphQL.Conventions.Tests.Adapters
             Type<Task<NonNull<List<TimeSpan>>>>().ShouldBeOfNonNullableListType<NonNullGraphType<TimeSpanGraphType>>();
             Type<Task<NonNull<List<Id>>>>().ShouldBeOfNonNullableListType<NonNullGraphType<Extended.IdGraphType>>();
             Type<Task<NonNull<List<NonNull<Url>>>>>().ShouldBeOfNonNullableListType<NonNullGraphType<UrlGraphType>>();
-            Type<Task<NonNull<List<NonNull<Uri>>>>>().ShouldBeOfNonNullableListType<NonNullGraphType<UriGraphType>>();
+            Type<Task<NonNull<List<NonNull<Uri>>>>>().ShouldBeOfNonNullableListType<NonNullGraphType<ConventionsTypes.UriGraphType>>();
             Type<Task<NonNull<List<Cursor>>>>().ShouldBeOfNonNullableListType<NonNullGraphType<Extended.Relay.CursorGraphType>>();
             Type<Task<NonNull<List<Guid>>>>().ShouldBeOfNonNullableListType<NonNullGraphType<GuidGraphType>>();
         }


### PR DESCRIPTION
## Description
This PR updates the GraphQL library version to v2.1 so it can be out of alpha.

## Notes and considerations for @tlil
* I had to fix 2 tests that I would like a second opinion on
* If I used the engine definition of `UriGraphType` then the tests on `UriGraphTypeTests` would actually break so I decided to keep it