### PR TITLE
Updated to GraphQL 2.4

### DIFF
--- a/samples/DataLoaderWithEFCore/DataLoaderWithEFCore/GraphApi/UserContext.cs
+++ b/samples/DataLoaderWithEFCore/DataLoaderWithEFCore/GraphApi/UserContext.cs
@@ -16,8 +16,7 @@ namespace DataLoaderWithEFCore.GraphApi
 
         public Task FetchData(CancellationToken token)
         {
-            _context.DispatchAll(token);
-            return Task.CompletedTask;
+            return _context.DispatchAllAsync(token);
         }
     }
 }

--- a/src/GraphQL.Conventions/Attributes/Execution/Unwrappers/CollectionUnwrapper.cs
+++ b/src/GraphQL.Conventions/Attributes/Execution/Unwrappers/CollectionUnwrapper.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Linq;
 using GraphQL.Conventions.Types.Resolution.Extensions;
 
 namespace GraphQL.Conventions.Attributes.Execution.Unwrappers
@@ -17,8 +18,10 @@ namespace GraphQL.Conventions.Attributes.Execution.Unwrappers
                 return value;
             }
 
+            //map was removed from GraphQL in https://github.com/graphql-dotnet/graphql-dotnet/commit/952b4ef6950e51bbfe009354f0520180c343e8d4#diff-992f25705b68d8de6f63113661c3a037
             var enumerable = value as IEnumerable;
-            return enumerable.Map(element => _parent.Unwrap(element));
+            return from object item in enumerable
+                   select _parent.Unwrap(item);
         }
     }
 }

--- a/src/GraphQL.Conventions/GraphQL.Conventions.csproj
+++ b/src/GraphQL.Conventions/GraphQL.Conventions.csproj
@@ -39,7 +39,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="GraphQL" Version="2.1.0" />
+    <PackageReference Include="GraphQL" Version="2.4.0" />
   </ItemGroup>
   
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/test/Tests/Adapters/TypeMappingTests.cs
+++ b/test/Tests/Adapters/TypeMappingTests.cs
@@ -9,6 +9,7 @@ using GraphQL.Conventions.Tests.Templates.Extensions;
 using GraphQL.Types;
 using Extended = GraphQL.Conventions.Adapters.Types;
 using UriGraphType = GraphQL.Conventions.Adapters.Types.UriGraphType;
+using GuidGraphType = GraphQL.Conventions.Adapters.Types.GuidGraphType;
 
 namespace GraphQL.Conventions.Tests.Adapters
 {

--- a/test/Tests/Templates/Extensions/TestExtensions.cs
+++ b/test/Tests/Templates/Extensions/TestExtensions.cs
@@ -191,9 +191,9 @@ namespace GraphQL.Conventions.Tests.Templates.Extensions
             {
                 if (k is int)
                 {
-                    var array = obj as object[];
+                    var array = obj as List<object>;
                     array.ShouldNotBeNull();
-                    array.Length.ShouldBeGreaterThan((int)k);
+                    array.Count.ShouldBeGreaterThan((int)k);
                     obj = array[(int)k];
                     obj.ShouldNotBeNull();
                 }
@@ -209,7 +209,7 @@ namespace GraphQL.Conventions.Tests.Templates.Extensions
             var key = path.Last();
             if (key is int)
             {
-                var array = obj as object[];
+                var array = obj as List<object>;
                 array.ShouldNotBeNull();
                 var output = array[(int)key];
                 output.ShouldEqual(value);
@@ -236,9 +236,9 @@ namespace GraphQL.Conventions.Tests.Templates.Extensions
                 obj = obj[key] as Dictionary<string, object>;
                 obj.ShouldNotBeNull();
             }
-            var array = obj[path.Last()] as object[];
+            var array = obj[path.Last()] as List<object>;
             array.ShouldNotBeNull();
-            array.Length.ShouldEqual(value ?? -1);
+            array.Count.ShouldEqual(value ?? -1);
         }
 
         private static string CleanMultilineText(string value)


### PR DESCRIPTION
- Newer version of GraphQL returns List<object> instead of object[], updated tests to pass.
- Map enumerable extension was removed from GraphQL, replaced it with the old code.