### PR TITLE
#170 Added ObjectReflector.IgnoreTypeCallback callback 

### DIFF
--- a/src/GraphQL.Conventions/Builders/SchemaConstructor.cs
+++ b/src/GraphQL.Conventions/Builders/SchemaConstructor.cs
@@ -147,6 +147,12 @@ namespace GraphQL.Conventions.Builders
             return this;
         }
 
+        public SchemaConstructor<TSchemaType, TGraphType> IgnoreTypes(Func<Type, MemberInfo, bool> ignoreTypeCallback)
+        {
+            _typeResolver.IgnoreTypes(ignoreTypeCallback);
+            return this;
+        }
+
         private class Query { }
 
         private class Mutation { }

--- a/src/GraphQL.Conventions/Extensions/Utilities.cs
+++ b/src/GraphQL.Conventions/Extensions/Utilities.cs
@@ -1,5 +1,6 @@
-using GraphQL.Conventions;
-using GraphQL.Conventions.Web;
+using System;
+using System.Linq;
+using System.Reflection;
 
 namespace GraphQL.Conventions.Extensions
 {
@@ -22,5 +23,12 @@ namespace GraphQL.Conventions.Extensions
 
         public static bool IsIdentifierForType<T>(this NonNull<string> id) =>
             id.Value.IsIdentifierForType<T>();
+
+        public static bool IsCastableTo<T>(this Type self) =>
+            self.IsCastableTo(typeof(T));
+
+        public static bool IsCastableTo(this Type self, params Type[] types) =>
+            types.Any(t => (t == self || t.IsAssignableFrom(self)));
+
     }
 }

--- a/src/GraphQL.Conventions/Extensions/Utilities.cs
+++ b/src/GraphQL.Conventions/Extensions/Utilities.cs
@@ -1,6 +1,5 @@
-using System;
-using System.Linq;
-using System.Reflection;
+using GraphQL.Conventions;
+using GraphQL.Conventions.Web;
 
 namespace GraphQL.Conventions.Extensions
 {
@@ -23,12 +22,5 @@ namespace GraphQL.Conventions.Extensions
 
         public static bool IsIdentifierForType<T>(this NonNull<string> id) =>
             id.Value.IsIdentifierForType<T>();
-
-        public static bool IsCastableTo<T>(this Type self) =>
-            self.IsCastableTo(typeof(T));
-
-        public static bool IsCastableTo(this Type self, params Type[] types) =>
-            types.Any(t => (t == self || t.IsAssignableFrom(self)));
-
     }
 }

--- a/src/GraphQL.Conventions/Types/Resolution/ITypeResolver.cs
+++ b/src/GraphQL.Conventions/Types/Resolution/ITypeResolver.cs
@@ -24,6 +24,8 @@ namespace GraphQL.Conventions.Types.Resolution
 
         void IgnoreTypesFromNamespacesStartingWith(params string[] namespacesToIgnore);
 
+        void IgnoreTypes(Func<Type, MemberInfo, bool> ignoreTypeCallback);
+
         void AddExtensions(Type typeExtensions);
 
         GraphSchemaInfo ActiveSchema { get; set; }

--- a/src/GraphQL.Conventions/Types/Resolution/ObjectReflector.cs
+++ b/src/GraphQL.Conventions/Types/Resolution/ObjectReflector.cs
@@ -169,12 +169,19 @@ namespace GraphQL.Conventions.Types.Resolution
             var interfaces = nativeInterfaces
                 .Where(t => IsValidType(t.GetTypeInfo()))
                 .Select(iface => GetType(iface.GetTypeInfo()))
-                .Where(iface => iface.IsInterfaceType && !iface.IsIgnored);
+                .Where(iface => IsValidInterface(iface));
 
             foreach (var iface in interfaces)
             {
                 type.AddInterface(iface);
             }
+        }
+
+        private  bool IsValidInterface(GraphTypeInfo iface)
+        {
+            return iface.IsInterfaceType 
+                && !iface.IsIgnored
+                && (IgnoreTypeCallback == null || !IgnoreTypeCallback(iface.GetType(), null));
         }
 
         private void DeriveFields(GraphTypeInfo type)

--- a/src/GraphQL.Conventions/Types/Resolution/TypeResolver.cs
+++ b/src/GraphQL.Conventions/Types/Resolution/TypeResolver.cs
@@ -98,7 +98,12 @@ namespace GraphQL.Conventions.Types.Resolution
                 _reflector.IgnoredNamespaces.Add(@namespace);
         }
 
+        public void IgnoreTypes(Func<Type, MemberInfo, bool> ignoreTypeCallback) {
+            _reflector.IgnoreTypeCallback = ignoreTypeCallback;
+        }
+
         public void AddExtensions(Type typeExtensions) =>
             _reflector.AddExtensions(typeExtensions.GetTypeInfo());
+
     }
 }

--- a/test/Tests/Builders/SchemaConstructorTests.cs
+++ b/test/Tests/Builders/SchemaConstructorTests.cs
@@ -95,7 +95,7 @@ namespace GraphQL.Conventions.Tests.Builders
             var schema = new SchemaConstructor<ISchema, IGraphType>(new GraphTypeAdapter())
                     .IgnoreTypes((Type t, MemberInfo m) => {
                         // Ignore based on the type:
-                        if (t.IsCastableTo<Unwanted.QueryType3>()) { return true; }
+                        if (t == typeof(Unwanted.QueryType3)) { return true; }
                         // Ignore based on name of the method:
                         if (m !=null && m.Name== "UpdateSomethingIgnored") { return true; }
                         return false;

--- a/test/Tests/Builders/SchemaConstructorTests.cs
+++ b/test/Tests/Builders/SchemaConstructorTests.cs
@@ -97,7 +97,7 @@ namespace GraphQL.Conventions.Tests.Builders
                         // Ignore based on the type:
                         if (t == typeof(Unwanted.QueryType3)) { return true; }
                         // Ignore based on name of the method:
-                        if (m !=null && m.Name== "UpdateSomethingIgnored") { return true; }
+                        if (m != null && m.Name == "UpdateSomethingIgnored") { return true; }
                         return false;
                     })
                     .Build(


### PR DESCRIPTION
Added ObjectReflector.IgnoreTypeCallback callback to allow excluding specific methods or properties from the generated schema to resolve #170 (See issue https://github.com/graphql-dotnet/conventions/issues/170 )