### PR TITLE
Make GraphTypeInfo.TypeParameter lazy

### DIFF
--- a/src/GraphQL.Conventions/Types/Resolution/ObjectReflector.cs
+++ b/src/GraphQL.Conventions/Types/Resolution/ObjectReflector.cs
@@ -102,6 +102,8 @@ namespace GraphQL.Conventions.Types.Resolution
                 return type;
             }
 
+            type.EnsureTypeParameterInitialized();
+
             var isInjectedType =
                 type.TypeRepresentation.AsType() == typeof(IResolutionContext) ||
                 type.TypeRepresentation.AsType() == typeof(IUserContext);


### PR DESCRIPTION
Deriving TypeParameter on constructor can be excessive in case you want to set it by yourself and also can lead to cyclic metadata derivation (e.g. when `Product` contains `IEnumerable<IProduct> RelatedProducts` field)