### PR TITLE
Using nullable types with Optional<> causes "Constructor not found" error

### DIFF
--- a/src/GraphQL.Conventions/Types/Optional.cs
+++ b/src/GraphQL.Conventions/Types/Optional.cs
@@ -52,6 +52,12 @@ namespace GraphQL.Conventions
             if (typeInfo.IsNullable &&
                 typeInfo.TypeRepresentation.IsGenericType(typeof(Optional<>)))
             {
+                var genericType = typeInfo.TypeRepresentation.GenericTypeArguments[0];
+                if (genericType.GetTypeInfo().IsGenericType(typeof(Nullable<>)) && value != null)
+                {
+                    // make value nullable to satisfy Optional constructor
+                    value = Activator.CreateInstance(genericType, new[] { value });
+                }
                 return Activator.CreateInstance(typeInfo.TypeRepresentation.AsType(), new[] { value, isSpecified });
             }
             else

--- a/test/Tests/Types/OptionalTests.cs
+++ b/test/Tests/Types/OptionalTests.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Reflection;
 using GraphQL.Conventions.Tests.Templates;
+using GraphQL.Conventions.Types.Resolution;
+using GraphQL.Conventions.Types.Descriptors;
 
 namespace GraphQL.Conventions.Tests.Types
 {
@@ -105,6 +108,43 @@ namespace GraphQL.Conventions.Tests.Types
         public void Can_Define_Url()
         {
             Optional<Url>.ValidateType();
+        }
+
+        [Test]
+        public void Can_Construct_WithNull()
+        {
+            var typeResolver = new TypeResolver();
+            var typeInfo = typeof(Optional<int?>).GetTypeInfo();
+            var graphTypeInfo = new GraphTypeInfo(typeResolver, typeInfo);
+            var optional = (Optional<int?>) Optional.Construct(graphTypeInfo, null, true);
+            Assert.IsNotNull(optional);
+            Assert.IsNull(optional.Value);
+        }
+
+        [Test]
+        public void Can_Construct_WithValueType()
+        {
+            int value = 2;
+            var typeResolver = new TypeResolver();
+            var typeInfo = typeof(Optional<int?>).GetTypeInfo();
+            var graphTypeInfo = new GraphTypeInfo(typeResolver, typeInfo);
+            var optional = (Optional<int?>)Optional.Construct(graphTypeInfo, value, true);
+            Assert.IsNotNull(optional);
+            Assert.IsNotNull(optional.Value);
+            Assert.AreEqual(value, optional.Value);
+        }
+
+        [Test]
+        public void Can_Construct_WithNullable()
+        {
+            int? value = 2;
+            var typeResolver = new TypeResolver();
+            var typeInfo = typeof(Optional<int?>).GetTypeInfo();
+            var graphTypeInfo = new GraphTypeInfo(typeResolver, typeInfo);
+            var optional = (Optional<int?>)Optional.Construct(graphTypeInfo, value, true);
+            Assert.IsNotNull(optional);
+            Assert.IsNotNull(optional.Value);
+            Assert.AreEqual(value, optional.Value);
         }
     }
 }


### PR DESCRIPTION
This PR fixes issue #185 by making value passed to Optional constructor nullable.