### PR TITLE
Expose DependencyInjector

### DIFF
--- a/src/GraphQL.Conventions/Adapters/Engine/GraphQLEngine.cs
+++ b/src/GraphQL.Conventions/Adapters/Engine/GraphQLEngine.cs
@@ -242,6 +242,12 @@ namespace GraphQL.Conventions
             return _schemaPrinter.Print();
         }
 
+        public ISchema GetSchema()
+        {
+            BuildSchema(); // Ensure that the schema has been constructed
+            return _schema;
+        }
+
         public GraphQLExecutor NewExecutor(IRequestDeserializer requestDeserializer = null)
         {
             BuildSchema(); // Ensure that the schema has been constructed

--- a/src/GraphQL.Conventions/Adapters/ResolutionContext.cs
+++ b/src/GraphQL.Conventions/Adapters/ResolutionContext.cs
@@ -57,9 +57,9 @@ namespace GraphQL.Conventions.Adapters
 
         public object RootValue => FieldContext.RootValue;
 
-        public IUserContext UserContext => (FieldContext.UserContext as UserContextWrapper)?.UserContext;
+        public IUserContext UserContext => (FieldContext.UserContext as IUserContextAccessor)?.UserContext;
 
-        public IDependencyInjector DependencyInjector => (FieldContext.UserContext as UserContextWrapper)?.DependencyInjector;
+        public IDependencyInjector DependencyInjector => (FieldContext.UserContext as IDependencyInjectorAccessor)?.DependencyInjector;
 
         public GraphFieldInfo FieldInfo { get; private set; }
 

--- a/src/GraphQL.Conventions/Execution/IUserContextAccessor.cs
+++ b/src/GraphQL.Conventions/Execution/IUserContextAccessor.cs
@@ -1,0 +1,7 @@
+﻿namespace GraphQL.Conventions.Execution
+{
+    public interface IUserContextAccessor
+    {
+        IUserContext UserContext { get; }
+    }
+}

--- a/src/GraphQL.Conventions/Execution/UserContextWrapper.cs
+++ b/src/GraphQL.Conventions/Execution/UserContextWrapper.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace GraphQL.Conventions.Execution
 {
-    class UserContextWrapper
+    public class UserContextWrapper : IUserContextAccessor, IDependencyInjectorAccessor
     {
         public static UserContextWrapper Create(IUserContext userContext, IDependencyInjector dependencyInjector)
         {

--- a/src/GraphQL.Conventions/Types/Resolution/DependencyInjectorExtensions.cs
+++ b/src/GraphQL.Conventions/Types/Resolution/DependencyInjectorExtensions.cs
@@ -1,0 +1,9 @@
+using System.Reflection;
+
+namespace GraphQL.Conventions
+{
+    public static class DependencyInjectorExtensions
+    {
+        public static T Resolve<T>(this IDependencyInjector dependencyInjector) => (T)dependencyInjector?.Resolve(typeof(T).GetTypeInfo());
+    }
+}

--- a/src/GraphQL.Conventions/Types/Resolution/IDependencyInjectorAccessor.cs
+++ b/src/GraphQL.Conventions/Types/Resolution/IDependencyInjectorAccessor.cs
@@ -1,0 +1,7 @@
+namespace GraphQL.Conventions
+{
+    public interface IDependencyInjectorAccessor
+    {
+        IDependencyInjector DependencyInjector { get; }
+    }
+}


### PR DESCRIPTION
Exposing DependencyInjector via UserContext/IDependencyInjectorAccessor interface.
This allow to replace the injector with a child scope before executing the query Before ExecutionStrategy).