### PR TITLE
Cancellation token support

### DIFF
--- a/src/GraphQL.Conventions/Handlers/ExecutionFilterAttributeHandler.cs
+++ b/src/GraphQL.Conventions/Handlers/ExecutionFilterAttributeHandler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using GraphQL.Conventions.Attributes.Execution.Unwrappers;
 using GraphQL.Conventions.Attributes.Execution.Wrappers;
@@ -56,6 +57,10 @@ namespace GraphQL.Conventions.Handlers
                     argumentType.ImplementedInterfaces.Any(iface => iface == typeof(IUserContext)))
                 {
                     obj = resolutionContext.UserContext;
+                }
+                else if (argumentType.AsType() == typeof(CancellationToken))
+                {
+                    obj = resolutionContext.CancellationToken;
                 }
                 else
                 {

--- a/src/GraphQL.Conventions/Types/Resolution/ObjectReflector.cs
+++ b/src/GraphQL.Conventions/Types/Resolution/ObjectReflector.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using GraphQL.Conventions.Handlers;
 using GraphQL.Conventions.Types.Descriptors;
@@ -334,6 +335,11 @@ namespace GraphQL.Conventions.Types.Resolution
                 argument.IsInjected = true;
             }
             else if (parameterType == typeof(IResolutionContext))
+            {
+                argument.Type = GetType(parameterTypeInfo, true);
+                argument.IsInjected = true;
+            }
+            else if (parameterType == typeof(CancellationToken))
             {
                 argument.Type = GetType(parameterTypeInfo, true);
                 argument.IsInjected = true;


### PR DESCRIPTION
At the moment, you can get CancellationToken in your method if you inject IResolutionContext.
This pull request allows you to directly accept CancellationToken as a method parameter.

See example:
```csharp
public async Task<BuildOutputResultModel> GetOutputAsync([Inject] JobsApi jobsApi, long offset, CancellationToken cancellationToken = default)
{
    var buildOutput = await jobsApi.GetBuildOutputAsync(jobName, Number, offset, cancellationToken);

    return new BuildOutputResultModel(buildOutput);
}
```
