### PR TITLE
Pass-through exceptions triggered within MethodInfo.Invoke

### DIFF
--- a/src/GraphQL.Conventions/Adapters/Engine/GraphQLEngine.cs
+++ b/src/GraphQL.Conventions/Adapters/Engine/GraphQLEngine.cs
@@ -9,6 +9,7 @@ using GraphQL.Conventions.Adapters.Engine.ErrorTransformations;
 using GraphQL.Conventions.Adapters.Engine.Listeners.DataLoader;
 using GraphQL.Conventions.Builders;
 using GraphQL.Conventions.Execution;
+using GraphQL.Conventions.Extensions;
 using GraphQL.Conventions.Types.Descriptors;
 using GraphQL.Conventions.Types.Resolution;
 using GraphQL.Execution;
@@ -366,7 +367,7 @@ namespace GraphQL.Conventions
                     var parameterValues = parameters
                         .Select(parameter => _constructor.TypeResolutionDelegate(parameter.ParameterType))
                         .ToArray();
-                    return ctor.Invoke(parameterValues);
+                    return ctor.InvokeEnhanced(parameterValues);
                 }
             }
 

--- a/src/GraphQL.Conventions/Adapters/Resolvers/FieldResolver.cs
+++ b/src/GraphQL.Conventions/Adapters/Resolvers/FieldResolver.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Reflection;
 using GraphQL.Conventions.Attributes.Execution.Unwrappers;
 using GraphQL.Conventions.Attributes.Execution.Wrappers;
+using GraphQL.Conventions.Extensions;
 using GraphQL.Conventions.Handlers;
 using GraphQL.Conventions.Relay;
 using GraphQL.Conventions.Types.Descriptors;
@@ -67,7 +68,7 @@ namespace GraphQL.Conventions.Adapters
             {
                 arguments = new[] { source }.Concat(arguments);
             }
-            var result = methodInfo?.Invoke(source, arguments.ToArray());
+            var result = methodInfo?.InvokeEnhanced(source, arguments.ToArray());
             return result;
         }
 

--- a/src/GraphQL.Conventions/Adapters/Resolvers/WrappedAsyncFieldResolver.cs
+++ b/src/GraphQL.Conventions/Adapters/Resolvers/WrappedAsyncFieldResolver.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using GraphQL.Conventions.Attributes.Execution.Unwrappers;
 using GraphQL.Conventions.Attributes.Execution.Wrappers;
+using GraphQL.Conventions.Extensions;
 using GraphQL.Conventions.Handlers;
 using GraphQL.Conventions.Relay;
 using GraphQL.Conventions.Types.Descriptors;
@@ -70,7 +71,7 @@ namespace GraphQL.Conventions.Adapters
                 return Task.Run(() => AsyncHelpers.RunTask(resolutionTask, fieldInfo.Type.TypeParameter()));
             }
 
-            return methodInfo?.Invoke(source, arguments.ToArray());
+            return methodInfo?.InvokeEnhanced(source, arguments.ToArray());
         }
 
         private object GetSource(GraphFieldInfo fieldInfo, IResolutionContext context)

--- a/src/GraphQL.Conventions/Adapters/Resolvers/WrappedSyncFieldResolver.cs
+++ b/src/GraphQL.Conventions/Adapters/Resolvers/WrappedSyncFieldResolver.cs
@@ -4,6 +4,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using GraphQL.Conventions.Attributes.Execution.Unwrappers;
 using GraphQL.Conventions.Attributes.Execution.Wrappers;
+using GraphQL.Conventions.Extensions;
 using GraphQL.Conventions.Handlers;
 using GraphQL.Conventions.Relay;
 using GraphQL.Conventions.Types.Descriptors;
@@ -69,7 +70,7 @@ namespace GraphQL.Conventions.Adapters
                 return AsyncHelpers.RunTask(resolutionTask, fieldInfo.Type.TypeParameter());
             }
 
-            return methodInfo?.Invoke(source, arguments.ToArray());
+            return methodInfo?.InvokeEnhanced(source, arguments.ToArray());
         }
 
         private object GetSource(GraphFieldInfo fieldInfo, IResolutionContext context)

--- a/src/GraphQL.Conventions/Extensions/Utilities.cs
+++ b/src/GraphQL.Conventions/Extensions/Utilities.cs
@@ -1,3 +1,11 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Security.Cryptography.X509Certificates;
+
 namespace GraphQL.Conventions.Extensions
 {
     public static class Utilities
@@ -19,5 +27,82 @@ namespace GraphQL.Conventions.Extensions
 
         public static bool IsIdentifierForType<T>(this NonNull<string> id) =>
             id.Value.IsIdentifierForType<T>();
+
+        /// <summary>
+        /// Invokes a method represented by a specified <see cref="MethodInfo"/>, using
+        /// the specified parameters.
+        /// </summary>
+        /// <param name="methodInfo">
+        /// The method representation.
+        /// </param>
+        /// <param name="instance">
+        /// The object on which to invoke the method. If the method is static, this
+        /// value is ignored.
+        /// </param>
+        /// <param name="arguments">
+        /// An argument list for the invoked method. This is an array of objects
+        /// with the same number, order, and type as the parameters of the method
+        /// to be invoked. If there are no parameters, parameters should be null.
+        /// Ref/out parameters are not supported.
+        /// </param>
+        /// <returns>
+        /// The return value from the method, or null for methods that return void.
+        /// </returns>
+        public static object InvokeEnhanced(this MethodInfo methodInfo, object instance, params object[] arguments)
+        {
+            //just good practice
+            if (methodInfo == null)
+                throw new ArgumentNullException(nameof(methodInfo));
+            //the following check is more descriptive than the NullReferenceException that would otherwise occur
+            if (!methodInfo.IsStatic && instance == null)
+                throw new ArgumentNullException(nameof(instance), "Instance is required for static methods");
+            //the lambda ignores extra arguments so the following check is necessary
+            if (methodInfo.GetParameters().Length != (arguments?.Length ?? 0))
+                throw new ArgumentException("Invalid number of arguments for this method", "arguments");
+            //type errors will be thrown as InvalidCastException inside the lambda
+
+            var lambda = _methodDictionary.GetOrAdd(methodInfo, InvokeEnhancedUncached);
+
+            return lambda(instance, arguments);
+        }
+        private static ConcurrentDictionary<MethodInfo, Func<object, object[], object>> _methodDictionary = new ConcurrentDictionary<MethodInfo, Func<object, object[], object>>();
+        private static Func<object, object[], object> InvokeEnhancedUncached(MethodInfo methodInfo)
+        {
+            var instanceParameter = Expression.Parameter(typeof(object));
+            var argumentsParameter = Expression.Parameter(typeof(object[]));
+            var instanceExpression = methodInfo.IsStatic ? null : Expression.Convert(instanceParameter, methodInfo.DeclaringType);
+            var methodParameters = methodInfo.GetParameters();
+            var parameters = methodParameters.Select((param, index) => {
+                return Expression.Convert(Expression.ArrayAccess(argumentsParameter, Expression.Constant(index)), param.ParameterType);
+            });
+            var call = Expression.Call(instanceExpression, methodInfo, parameters);
+            Expression body;
+            if (methodInfo.ReturnType == typeof(void))
+            {
+                body = Expression.Block(new Expression[] {
+                    call,
+                    Expression.Constant(null, typeof(object))
+                });
+            }
+            else
+            {
+                body = Expression.Convert(call, typeof(object));
+            }
+            var lambda = Expression.Lambda<Func<object, object[], object>>(body, instanceParameter, argumentsParameter);
+            return lambda.Compile();
+        }
+
+        public static object InvokeEnhanced(this ConstructorInfo constructorInfo, params object[] parameters)
+        {
+            try
+            {
+                return constructorInfo.Invoke(parameters);
+            }
+            catch (TargetInvocationException ex)
+            {
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                throw ex.InnerException; //required for intellisense
+            }
+        }
     }
 }

--- a/src/GraphQL.Conventions/Extensions/Utilities.cs
+++ b/src/GraphQL.Conventions/Extensions/Utilities.cs
@@ -97,7 +97,7 @@ namespace GraphQL.Conventions.Extensions
         /// the specified parameters.
         /// </summary>
         /// <param name="constructorInfo">
-        /// The constructor representation.
+        /// The constructor representation. Must not be a static constructor.
         /// </param>
         /// <param name="arguments">
         /// An argument list for the invoked constructor. This is an array of objects

--- a/src/GraphQL.Conventions/Extensions/Utilities.cs
+++ b/src/GraphQL.Conventions/Extensions/Utilities.cs
@@ -55,7 +55,7 @@ namespace GraphQL.Conventions.Extensions
                 throw new ArgumentNullException(nameof(methodInfo));
             //the following check is more descriptive than the NullReferenceException that would otherwise occur
             if (!methodInfo.IsStatic && instance == null)
-                throw new ArgumentNullException(nameof(instance), "Instance is required for static methods");
+                throw new ArgumentNullException(nameof(instance), "Instance is required for non static methods");
             //the lambda ignores extra arguments so the following check is necessary
             if (methodInfo.GetParameters().Length != (arguments?.Length ?? 0))
                 throw new ArgumentException("Invalid number of arguments for this method", "arguments");

--- a/src/GraphQL.Conventions/Extensions/Utilities.cs
+++ b/src/GraphQL.Conventions/Extensions/Utilities.cs
@@ -48,7 +48,7 @@ namespace GraphQL.Conventions.Extensions
         /// <returns>
         /// The return value from the method, or null for methods that return void.
         /// </returns>
-        public static object InvokeEnhanced(this MethodInfo methodInfo, object instance, params object[] arguments)
+        public static object InvokeEnhanced(this MethodInfo methodInfo, object instance, object[] arguments)
         {
             //just good practice
             if (methodInfo == null)
@@ -92,7 +92,7 @@ namespace GraphQL.Conventions.Extensions
             return lambda.Compile();
         }
 
-        public static object InvokeEnhanced(this ConstructorInfo constructorInfo, params object[] parameters)
+        public static object InvokeEnhanced(this ConstructorInfo constructorInfo, object[] parameters)
         {
             try
             {

--- a/src/GraphQL.Conventions/Types/Resolution/Extensions/ReflectionExtensions.cs
+++ b/src/GraphQL.Conventions/Types/Resolution/Extensions/ReflectionExtensions.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using GraphQL.Conventions.Extensions;
 using GraphQL.Conventions.Types.Descriptors;
 
 namespace GraphQL.Conventions.Types.Resolution.Extensions
@@ -115,7 +116,7 @@ namespace GraphQL.Conventions.Types.Resolution.Extensions
                 .GetTypeInfo()
                 .GetMethod("ConvertToArray", BindingFlags.Static | BindingFlags.Public);
             var genericMethod = convertMethod.MakeGenericMethod(elementType);
-            return genericMethod.Invoke(null, new object[] { list });
+            return genericMethod.InvokeEnhanced(null, new object[] { list });
         }
 
         public static bool IsExtensionMethod(this MethodInfo methodInfo)

--- a/src/GraphQL.Conventions/Utilities/AsyncHelpers.cs
+++ b/src/GraphQL.Conventions/Utilities/AsyncHelpers.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using GraphQL.Conventions.Extensions;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
@@ -49,7 +50,7 @@ namespace GraphQL.Conventions
                 var asyncMethod = typeof(AsyncHelpers)
                     .GetMethod(nameof(RunSync))
                     .MakeGenericMethod(typeInfo.AsType());
-                return asyncMethod.Invoke(null, new object[] { task });
+                return asyncMethod.InvokeEnhanced(null, new object[] { task });
             }
             catch (Exception ex)
             {

--- a/test/GraphQL.Conventions.Tests/Adapters/Engine/CustomErrorTransformationTests.cs
+++ b/test/GraphQL.Conventions.Tests/Adapters/Engine/CustomErrorTransformationTests.cs
@@ -42,8 +42,7 @@ namespace GraphQL.Conventions.Tests.Adapters.Engine
             result.Errors.Count.ShouldEqual(1);
             var error = result.Errors.First();
             error.ShouldBeOfType<ExecutionError>();
-            error.InnerException.ShouldBeOfType<TargetInvocationException>();
-            error.InnerException.InnerException.ShouldBeOfType<CustomException>();
+            error.InnerException.ShouldBeOfType<CustomException>();
         }
 
         class Query

--- a/test/GraphQL.Conventions.Tests/Extensions/Utilities_InvokeTests.cs
+++ b/test/GraphQL.Conventions.Tests/Extensions/Utilities_InvokeTests.cs
@@ -1,0 +1,144 @@
+﻿using GraphQL.Conventions.Extensions;
+using GraphQL.Conventions.Tests;
+using System;
+using System.Reflection;
+
+namespace Tests.Extensions
+{
+    public class Utilities_InvokeTests
+    {
+        [Test]
+        public void Static_Method_Returns_ValueType()
+        {
+            Assert.AreEqual(2, GetMethodInfo(nameof(StaticTest1)).InvokeEnhanced(null));
+        }
+        private static int StaticTest1() => 2;
+
+        [Test]
+        public void Static_Method_Returns_ObjectType()
+        {
+            Assert.AreEqual("hello", GetMethodInfo(nameof(StaticTest2)).InvokeEnhanced(null));
+        }
+        private static string StaticTest2() => "hello";
+
+        [Test]
+        public void Static_Method_Returns_Void()
+        {
+            StaticTest3Ran = false;
+            Assert.IsNull(GetMethodInfo(nameof(StaticTest3)).InvokeEnhanced(null));
+            Assert.IsTrue(StaticTest3Ran);
+        }
+        private static void StaticTest3() => StaticTest3Ran = true;
+        private static bool StaticTest3Ran;
+
+        [Test]
+        public void Instance_Method_Returns_ValueType()
+        {
+            Assert.AreEqual(2, GetMethodInfo(nameof(InstanceTest1)).InvokeEnhanced(this));
+        }
+        private int InstanceTest1() => 2;
+
+        [Test]
+        public void Instance_Method_Returns_ObjectType()
+        {
+            Assert.AreEqual("hello", GetMethodInfo(nameof(InstanceTest2)).InvokeEnhanced(this));
+        }
+        private string InstanceTest2() => "hello";
+
+        [Test]
+        public void Instance_Method_Returns_Void()
+        {
+            InstanceTest3Ran = false;
+            Assert.IsNull(GetMethodInfo(nameof(InstanceTest3)).InvokeEnhanced(this));
+            Assert.IsTrue(InstanceTest3Ran);
+        }
+        private void InstanceTest3() => InstanceTest3Ran = true;
+        private bool InstanceTest3Ran;
+
+        [Test]
+        public void Static_Method_WithParams()
+        {
+            Assert.AreEqual("Static Received 00000000-0000-0000-0000-000000000000 98 55", GetMethodInfo(nameof(StaticWithParams)).InvokeEnhanced(null, Guid.Empty, new MyObject(98), 55));
+        }
+        private static string StaticWithParams(Guid guid, MyObject stream, int? value) => $"Static Received {guid} {stream} {value}";
+
+        [Test]
+        public void Instance_Method_WithParams()
+        {
+            Assert.AreEqual("Instance Received 00000000-0000-0000-0000-000000000000 99 56", GetMethodInfo(nameof(InstanceWithParams)).InvokeEnhanced(this, Guid.Empty, new MyObject(99), 56));
+        }
+        private string InstanceWithParams(Guid guid, MyObject stream, int? value) => $"Instance Received {guid} {stream} {value}";
+
+        [Test]
+        public void Static_ThrowsExceptions()
+        {
+            try
+            {
+                GetMethodInfo(nameof(StaticThrows)).InvokeEnhanced(null);
+            }
+            catch (Exception e)
+            {
+                Assert.AreEqual("test exception", e.Message);
+            }
+        }
+        private static void StaticThrows() => throw new Exception("test exception");
+
+        [Test]
+        public void Instance_ThrowsExceptions()
+        {
+            try
+            {
+                GetMethodInfo(nameof(InstanceThrows)).InvokeEnhanced(this);
+            }
+            catch (Exception e)
+            {
+                Assert.AreEqual("test exception2", e.Message);
+            }
+        }
+        private void InstanceThrows() => throw new Exception("test exception2");
+
+        [Test]
+        public void Requires_MethodInfo()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => Utilities.InvokeEnhanced((MethodInfo)null, null));
+        }
+
+        [Test]
+        public void Requires_Instance_For_Instance_Methods()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => Utilities.InvokeEnhanced(GetMethodInfo(nameof(InstanceTest1)), null));
+        }
+
+        [Test]
+        public void Ignores_Instance_For_Static_Methods()
+        {
+            Assert.AreEqual(2, GetMethodInfo(nameof(StaticTest1)).InvokeEnhanced(this));
+        }
+
+        [Test]
+        public void Wrong_Arguments_Throws()
+        {
+            Assert.ThrowsException<ArgumentException>(() => GetMethodInfo(nameof(StaticTest1)).InvokeEnhanced(null, 1));
+        }
+
+        [Test]
+        public void RefArgument_Throws()
+        {
+            Assert.ThrowsException<ArgumentException>(() => GetMethodInfo(nameof(StaticRefTest1)).InvokeEnhanced(null, new object[] { 1 }));
+        }
+        private static void StaticRefTest1(ref int value) => value = 2;
+
+        private MethodInfo GetMethodInfo(string name) => typeof(Utilities_InvokeTests).GetMethod(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
+
+        private class MyObject
+        {
+            private int _int;
+            public MyObject(int value) => _int = value;
+            public override string ToString()
+            {
+                return _int.ToString();
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
An extension method has been added called `InvokeEnhanced` which will execute nearly identical to `Invoke` except for the fact that exceptions will not be wrapped within a `TargetInvocationException`.  The only difference is that `ref` parameters are not supported.  This could fall-back to use `MethodInfo.Invoke`, but as the result is typically discarded, it would seem more logical to disallow ref parameters.  The code compiles a `Func<>` at runtime and caches it in a static `ConcurrentDictionary<>` for each `MethodInfo`.

~~I have also added exception-unwrapping to `ConstructorInfo.Invoke`, within a new `InvokeEnhanced` method, but it simply catches the exception and rethrows the inner exception while retaining the stack trace.  This could be enhanced similarly to above, but this probably has less value as it would normally be used for data classes that do not have code inside the default constructor.~~ The same was done for `ConstructorInfo.Invoke`; now a new `InvokeEnhanced` method works in the same fashion as described above.

There are two benefits to dynamically compiling an invoke method for each `MethodInfo`:
- There is no additional information in the stack trace added for the rethrown exception.
- Debugging errors within Visual Studio will not break within GraphQL.Conventions due to the rethrown exception.

Extensive tests have been added for the new extension methods.  The new extension methods have been marked `public`.  They can be `internal`, although for the tests to work we would need to add a `InternalsVisibleToAttribute` to expose the internal methods to the test project.