### PR TITLE
Migrate GraphQL.NET to 4.1.0

### DIFF
--- a/src/GraphQL.Conventions/Adapters/Engine/GraphQLEngine.cs
+++ b/src/GraphQL.Conventions/Adapters/Engine/GraphQLEngine.cs
@@ -285,7 +285,7 @@ namespace GraphQL.Conventions
             {
                 rules = new[] { new NoopValidationRule() };
             }
-            
+
             var validationRules = rules?.ToArray() ?? new IValidationRule[0];
             var configuration = new ExecutionOptions
             {
@@ -316,7 +316,6 @@ namespace GraphQL.Conventions
                 configuration.Listeners.Add(new DataLoaderListener());
             }
 
-            //TODO : refactor todo in schemabuilder
             if (enableProfiling)
             {
                 _schema.FieldMiddleware.Use(dependencyInjector.Resolve<InstrumentFieldsMiddleware>());

--- a/src/GraphQL.Conventions/Adapters/GraphTypeAdapter.cs
+++ b/src/GraphQL.Conventions/Adapters/GraphTypeAdapter.cs
@@ -91,7 +91,6 @@ namespace GraphQL.Conventions.Adapters
                     Name = fieldInfo.Name,
                     Description = fieldInfo.Description,
                     DeprecationReason = fieldInfo.DeprecationReason,
-                    Metadata = DeriveFieldTypeMetaData(fieldInfo.AttributeProvider.GetCustomAttributes(false)),
                     DefaultValue = fieldInfo.DefaultValue,
                     Type = GetType(fieldInfo.Type),
                     Arguments = new QueryArguments(fieldInfo.Arguments.Where(arg => !arg.IsInjected).Select(DeriveArgument)),
@@ -105,7 +104,6 @@ namespace GraphQL.Conventions.Adapters
                 Description = fieldInfo.Description,
                 DeprecationReason = fieldInfo.DeprecationReason,
                 DefaultValue = fieldInfo.DefaultValue,
-                Metadata = DeriveFieldTypeMetaData(fieldInfo.AttributeProvider.GetCustomAttributes(false)),
                 Type = GetType(fieldInfo.Type),
                 Arguments = new QueryArguments(fieldInfo.Arguments.Where(arg => !arg.IsInjected).Select(DeriveArgument)),
                 Resolver = FieldResolverFactory(fieldInfo),
@@ -163,7 +161,7 @@ namespace GraphQL.Conventions.Adapters
                     return typeof(DateTimeOffsetGraphType);
 
                 case TypeNames.Id:
-                    return typeof(IdGraphType);
+                    return typeof(Types.IdGraphType);
 
                 case TypeNames.Cursor:
                     return typeof(Types.Relay.CursorGraphType);
@@ -343,9 +341,15 @@ namespace GraphQL.Conventions.Adapters
 
         private void DeriveFields(GraphTypeInfo typeInfo, IComplexGraphType graphType)
         {
-            foreach (var field in typeInfo.Fields.Select(DeriveField))
+            foreach (var field in typeInfo.Fields)
             {
-                graphType.AddField(field);
+                var derivedField = DeriveField(field);
+                var derivedMetadata = DeriveFieldTypeMetaData(field.AttributeProvider.GetCustomAttributes(false));
+
+                foreach (var item in derivedMetadata)
+                    derivedField.Metadata[item.Key] = item.Value;
+
+                graphType.AddField(derivedField);
             }
         }
     }

--- a/src/GraphQL.Conventions/Adapters/ResolutionContext.cs
+++ b/src/GraphQL.Conventions/Adapters/ResolutionContext.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using GraphQL.Conventions.Execution;
 using GraphQL.Conventions.Types.Descriptors;
+using GraphQL.Execution;
 
 namespace GraphQL.Conventions.Adapters
 {
@@ -26,7 +27,7 @@ namespace GraphQL.Conventions.Adapters
                 if (FieldContext.Arguments != null &&
                     FieldContext.Arguments.TryGetValue(name, out var value))
                 {
-                    return value;
+                    return value.Value;
                 }
                 return defaultValue;
             }
@@ -48,9 +49,9 @@ namespace GraphQL.Conventions.Adapters
             {
                 if (FieldContext.Arguments == null)
                 {
-                    FieldContext.Arguments = new Dictionary<string, object>();
+                    FieldContext.Arguments = new Dictionary<string, ArgumentValue>();
                 }
-                FieldContext.Arguments[name] = value;
+                FieldContext.Arguments[name] = new ArgumentValue(value, ArgumentSource.Variable);
             }
         }
 

--- a/src/GraphQL.Conventions/Adapters/Types/IdGraphType.cs
+++ b/src/GraphQL.Conventions/Adapters/Types/IdGraphType.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using GraphQL.Language.AST;
+
+namespace GraphQL.Conventions.Adapters.Types
+{
+    public class IdGraphType : GraphQL.Types.IdGraphType
+    {
+        /// <inheritdoc/>
+        public override object ParseValue(object value) => value != null 
+            ? new Id(value.ToString()) 
+            : null;
+    }
+}

--- a/src/GraphQL.Conventions/Builders/SchemaConstructor.cs
+++ b/src/GraphQL.Conventions/Builders/SchemaConstructor.cs
@@ -44,6 +44,11 @@ namespace GraphQL.Conventions.Builders
                 .Select(_typeResolver.DeriveSchema)
                 .ToList() ?? new List<GraphSchemaInfo>();
 
+            if (schemaInfos.All(s => s.Query == null))
+            {
+                throw new ArgumentException("Schema has no query type.");
+            }
+
             var schemaInfo = schemaInfos.FirstOrDefault();
             if (schemaInfo == null)
             {

--- a/src/GraphQL.Conventions/CommonAssemblyInfo.cs
+++ b/src/GraphQL.Conventions/CommonAssemblyInfo.cs
@@ -8,8 +8,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright("Copyright 2016-2019 Tommy Lillehagen. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("3.3.2")]
-[assembly: AssemblyInformationalVersion("3.3.2")]
+[assembly: AssemblyFileVersion("4.0.0")]
+[assembly: AssemblyInformationalVersion("4.0.0")]
 [assembly: CLSCompliant(false)]
 
 [assembly: InternalsVisibleTo("Tests")]

--- a/src/GraphQL.Conventions/GraphQL.Conventions.csproj
+++ b/src/GraphQL.Conventions/GraphQL.Conventions.csproj
@@ -27,13 +27,11 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <LangVersion>7.3</LangVersion>
-  </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="GraphQL" Version="3.3.2" />
-    <PackageReference Include="GraphQL.NewtonsoftJson" Version="3.3.2" />
+    <PackageReference Include="GraphQL" Version="4.0.2" />
+    <PackageReference Include="GraphQL.DataLoader" Version="4.0.2" />
+    <PackageReference Include="GraphQL.NewtonsoftJson" Version="4.0.2" />
+    <PackageReference Include="GraphQL.SystemReactive" Version="4.0.2" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />

--- a/src/GraphQL.Conventions/GraphQL.Conventions.csproj
+++ b/src/GraphQL.Conventions/GraphQL.Conventions.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <Description>GraphQL Conventions for .NET</Description>
-    <VersionPrefix>3.3.2</VersionPrefix>
-    <PackageVersion>3.3.2</PackageVersion>
+    <VersionPrefix>4.0.0</VersionPrefix>
+    <PackageVersion>4.0.0</PackageVersion>
     <Authors>Tommy Lillehagen</Authors>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <DepsFileGenerationMode>old</DepsFileGenerationMode>
@@ -28,10 +28,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL" Version="4.0.2" />
-    <PackageReference Include="GraphQL.DataLoader" Version="4.0.2" />
-    <PackageReference Include="GraphQL.NewtonsoftJson" Version="4.0.2" />
-    <PackageReference Include="GraphQL.SystemReactive" Version="4.0.2" />
+    <PackageReference Include="GraphQL" Version="4.1.0" />
+    <PackageReference Include="GraphQL.DataLoader" Version="4.1.0" />
+    <PackageReference Include="GraphQL.NewtonsoftJson" Version="4.1.0" />
+    <PackageReference Include="GraphQL.SystemReactive" Version="4.1.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />

--- a/src/GraphQL.Conventions/Types/SchemaDefinition.cs
+++ b/src/GraphQL.Conventions/Types/SchemaDefinition.cs
@@ -7,20 +7,20 @@ namespace GraphQL.Conventions
     }
 
     public class SchemaDefinitionWithMutation<TMutation>
-        : SchemaDefinition<Query, TMutation>
     {
+        public TMutation Mutation { get; set; }
     }
 
     public class SchemaDefinitionWithSubscription<TSubscription>
     {
-        public Query Query { get; set; }
-
         public TSubscription Subscription { get; set; }
     }
 
     public class SchemaDefinitionWithMutationAndSubscription<TMutation, TSubscription>
-        : SchemaDefinition<Query, TMutation, TSubscription>
     {
+        public TMutation Mutation { get; set; }
+
+        public TSubscription Subscription { get; set; }
     }
 
     public class SchemaDefinition<TQuery, TMutation>
@@ -37,9 +37,5 @@ namespace GraphQL.Conventions
         public TMutation Mutation { get; set; }
 
         public TSubscription Subscription { get; set; }
-    }
-
-    public class Query
-    {
     }
 }

--- a/test/GraphQL.Conventions.Tests/Adapters/Engine/AbstractTypeConstructionTests.cs
+++ b/test/GraphQL.Conventions.Tests/Adapters/Engine/AbstractTypeConstructionTests.cs
@@ -17,7 +17,7 @@ namespace Tests.Adapters.Engine
             var schema = engine.Describe();
             schema.ShouldEqualWhenReformatted(@"
             type Query {
-                commonField(value: DateTime!): DateTime!
+                commonField(value: Int!): Int!
                 someOtherField: String
             }
             ");
@@ -29,12 +29,12 @@ namespace Tests.Adapters.Engine
             var engine = GraphQLEngine.New<Query>();
             var result = await engine
                 .NewExecutor()
-                .WithQueryString("{ commonField(value: \"1970-01-01T00:00:00Z\") someOtherField }")
+                .WithQueryString("{ commonField(value: 1) someOtherField }")
                 .EnableValidation()
                 .ExecuteAsync();
 
             result.ShouldHaveNoErrors();
-            result.Data.ShouldHaveFieldWithValue("commonField", new DateTime(1970, 1, 1));
+            result.Data.ShouldHaveFieldWithValue("commonField", 1);
             result.Data.ShouldHaveFieldWithValue("someOtherField", string.Empty);
         }
 
@@ -43,7 +43,7 @@ namespace Tests.Adapters.Engine
             public T CommonField(T value) => value;
         }
 
-        class Query : EntityQuery<DateTime>
+        class Query : EntityQuery<int>
         {
             public string SomeOtherField => string.Empty;
         }

--- a/test/GraphQL.Conventions.Tests/Adapters/Engine/DependencyInjectionTests.cs
+++ b/test/GraphQL.Conventions.Tests/Adapters/Engine/DependencyInjectionTests.cs
@@ -215,7 +215,7 @@ namespace Tests.Adapters.Engine
                     _injector = injector;
                     _innerStrategy = innerStrategy;
                 }
-                
+
                 public async Task<ExecutionResult> ExecuteAsync(ExecutionContext context)
                 {
                     var key = typeof(IDependencyInjector).FullName ?? nameof(IDependencyInjector);

--- a/test/GraphQL.Conventions.Tests/Adapters/Engine/DependencyInjectionTests.cs
+++ b/test/GraphQL.Conventions.Tests/Adapters/Engine/DependencyInjectionTests.cs
@@ -1,9 +1,12 @@
+using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
 using GraphQL;
 using GraphQL.Conventions;
 using GraphQL.Conventions.Execution;
 using GraphQL.Execution;
+using GraphQL.Language.AST;
 using Tests.Templates;
 using Tests.Templates.Extensions;
 
@@ -178,6 +181,10 @@ namespace Tests.Adapters.Engine
                 {
                     return new ChildDependencyInjector($"{_value}->ChildScope");
                 }
+                if (typeInfo.GetConstructor(Type.EmptyTypes) != null)
+                {
+                    return Activator.CreateInstance(typeInfo.AsType());
+                }
                 return null;
             }
         }
@@ -208,7 +215,7 @@ namespace Tests.Adapters.Engine
                     _injector = injector;
                     _innerStrategy = innerStrategy;
                 }
-
+                
                 public async Task<ExecutionResult> ExecuteAsync(ExecutionContext context)
                 {
                     var key = typeof(IDependencyInjector).FullName ?? nameof(IDependencyInjector);
@@ -223,6 +230,11 @@ namespace Tests.Adapters.Engine
                     {
                         context.UserContext[key] = outerInjector;
                     }
+                }
+
+                public Dictionary<string, Field> GetSubFields(ExecutionContext executionContext, ExecutionNode executionNode)
+                {
+                    return _innerStrategy.GetSubFields(executionContext, executionNode);
                 }
             }
         }

--- a/test/GraphQL.Conventions.Tests/Adapters/Engine/Types/CustomJsonGraphType.cs
+++ b/test/GraphQL.Conventions.Tests/Adapters/Engine/Types/CustomJsonGraphType.cs
@@ -6,21 +6,6 @@ using GraphQL.Types;
 
 namespace Tests.Adapters.Engine.Types
 {
-    #region GraphTypeConverter
-    public class JsonGraphTypeConverter : IAstFromValueConverter
-    {
-        public bool Matches(object value, IGraphType type)
-        {
-            return type.Name == nameof(JSON);
-        }
-
-        public IValue Convert(object value, IGraphType type)
-        {
-            return new JSON(value as IDictionary<string, object>);
-        }
-    }
-    #endregion
-
     #region .NET Class
     public class JSON : ValueNode<IDictionary<string, object>>
     {
@@ -32,11 +17,6 @@ namespace Tests.Adapters.Engine.Types
         public JSON(IDictionary<string, object> value)
         {
             Value = value;
-        }
-
-        protected override bool Equals(ValueNode<IDictionary<string, object>> node)
-        {
-            return Value == node.Value;
         }
     }
     #endregion
@@ -73,6 +53,11 @@ namespace Tests.Adapters.Engine.Types
         {
             var jsonValue = value as JSON;
             return jsonValue?.Value;
+        }
+
+        public override IValue ToAST(object value)
+        {
+            return new JSON(value as IDictionary<string, object>);
         }
     }
     #endregion

--- a/test/GraphQL.Conventions.Tests/Adapters/EventStreamResolverTest.cs
+++ b/test/GraphQL.Conventions.Tests/Adapters/EventStreamResolverTest.cs
@@ -5,6 +5,7 @@ using GraphQL.Conventions;
 using GraphQL.Conventions.Adapters.Resolvers;
 using GraphQL.Subscription;
 using Tests.Templates;
+using Tests.Types;
 
 namespace Tests.Adapters
 {
@@ -23,7 +24,9 @@ namespace Tests.Adapters
         [Test]
         public async Task Can_Subscribe()
         {
-            var engine = GraphQLEngine.New().WithSubscription<Subscription>();
+            var engine = GraphQLEngine.New(new SubscriptionDocumentExecuter())
+                .WithQuery<TestQuery>()
+                .WithSubscription<Subscription>();
             var result = await engine
                 .NewExecutor()
                 .WithQueryString("subscription { test }")

--- a/test/GraphQL.Conventions.Tests/Adapters/FieldDerivationTests.cs
+++ b/test/GraphQL.Conventions.Tests/Adapters/FieldDerivationTests.cs
@@ -6,6 +6,7 @@ using GraphQL.Types;
 using Tests.Templates;
 using Tests.Templates.Extensions;
 
+using Extended = GraphQL.Conventions.Adapters.Types;
 // ReSharper disable UnusedMember.Local
 
 namespace Tests.Adapters
@@ -124,7 +125,7 @@ namespace Tests.Adapters
             type.Name.ShouldEqual("Fooz");
             type.Description.ShouldEqual("Foo bar baz");
             type.ShouldHaveFields(3);
-            type.ShouldHaveFieldWithName("id").OfType<NonNullGraphType<IdGraphType>>();
+            type.ShouldHaveFieldWithName("id").OfType<NonNullGraphType<Extended.IdGraphType>>();
             type.ShouldHaveFieldWithName("a").OfType<IntGraphType>();
             type.ShouldHaveFieldWithName("b").OfType<NonNullGraphType<IntGraphType>>();
         }

--- a/test/GraphQL.Conventions.Tests/Adapters/TypeConstructionTests.cs
+++ b/test/GraphQL.Conventions.Tests/Adapters/TypeConstructionTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using GraphQL;
 using GraphQL.Conventions;
 using GraphQL.Conventions.Relay;
 using GraphQL.Conventions.Types.Resolution;
@@ -133,7 +134,7 @@ namespace Tests.Adapters
         public void Bug190_Discover_Possible_Types_From_Lists()
         {
             var schema = GraphQLEngine.New<Bug190Query_2>().GetSchema();
-            var type = schema.FindType(nameof(Bug190Query_2.TestImpl));
+            var type = new SchemaTypes(schema, new DefaultServiceProvider())[nameof(Bug190Query_2.TestImpl)];
             type.ShouldNotBeNull();
         }
 

--- a/test/GraphQL.Conventions.Tests/Adapters/TypeMappingTests.cs
+++ b/test/GraphQL.Conventions.Tests/Adapters/TypeMappingTests.cs
@@ -35,7 +35,7 @@ namespace Tests.Adapters
             Type<DateTime?>().ShouldBeOfType<DateTimeGraphType>();
             Type<DateTimeOffset?>().ShouldBeOfType<DateTimeOffsetGraphType>();
             Type<TimeSpan?>().ShouldBeOfType<Extended.TimeSpanGraphType>();
-            Type<Id?>().ShouldBeOfType<IdGraphType>();
+            Type<Id?>().ShouldBeOfType<Extended.IdGraphType>();
             Type<Url>().ShouldBeOfType<Extended.UrlGraphType>();
             Type<Uri>().ShouldBeOfType<UriGraphType>();
             Type<Cursor?>().ShouldBeOfType<Extended.Relay.CursorGraphType>();
@@ -61,7 +61,7 @@ namespace Tests.Adapters
             Type<DateTime>().ShouldBeOfNonNullableType<DateTimeGraphType>();
             Type<DateTimeOffset>().ShouldBeOfNonNullableType<DateTimeOffsetGraphType>();
             Type<TimeSpan>().ShouldBeOfNonNullableType<Extended.TimeSpanGraphType>();
-            Type<Id>().ShouldBeOfNonNullableType<IdGraphType>();
+            Type<Id>().ShouldBeOfNonNullableType<Extended.IdGraphType>();
             Type<NonNull<Url>>().ShouldBeOfNonNullableType<Extended.UrlGraphType>();
             Type<NonNull<Uri>>().ShouldBeOfNonNullableType<UriGraphType>();
             Type<Cursor>().ShouldBeOfNonNullableType<Extended.Relay.CursorGraphType>();
@@ -137,7 +137,7 @@ namespace Tests.Adapters
             Type<List<DateTime?>>().ShouldBeOfListType<DateTimeGraphType>();
             Type<List<DateTimeOffset?>>().ShouldBeOfListType<DateTimeOffsetGraphType>();
             Type<List<TimeSpan?>>().ShouldBeOfListType<Extended.TimeSpanGraphType>();
-            Type<List<Id?>>().ShouldBeOfListType<IdGraphType>();
+            Type<List<Id?>>().ShouldBeOfListType<Extended.IdGraphType>();
             Type<List<Url>>().ShouldBeOfListType<Extended.UrlGraphType>();
             Type<List<Uri>>().ShouldBeOfListType<UriGraphType>();
             Type<List<Cursor?>>().ShouldBeOfListType<Extended.Relay.CursorGraphType>();
@@ -163,7 +163,7 @@ namespace Tests.Adapters
             Type<List<DateTime>>().ShouldBeOfListType<NonNullGraphType<DateTimeGraphType>>();
             Type<List<DateTimeOffset>>().ShouldBeOfListType<NonNullGraphType<DateTimeOffsetGraphType>>();
             Type<List<TimeSpan>>().ShouldBeOfListType<NonNullGraphType<Extended.TimeSpanGraphType>>();
-            Type<List<Id>>().ShouldBeOfListType<NonNullGraphType<IdGraphType>>();
+            Type<List<Id>>().ShouldBeOfListType<NonNullGraphType<Extended.IdGraphType>>();
             Type<List<NonNull<Url>>>().ShouldBeOfListType<NonNullGraphType<Extended.UrlGraphType>>();
             Type<List<NonNull<Uri>>>().ShouldBeOfListType<NonNullGraphType<UriGraphType>>();
             Type<List<Cursor>>().ShouldBeOfListType<NonNullGraphType<Extended.Relay.CursorGraphType>>();
@@ -239,7 +239,7 @@ namespace Tests.Adapters
             Type<NonNull<List<DateTime?>>>().ShouldBeOfNonNullableListType<DateTimeGraphType>();
             Type<NonNull<List<DateTimeOffset?>>>().ShouldBeOfNonNullableListType<DateTimeOffsetGraphType>();
             Type<NonNull<List<TimeSpan?>>>().ShouldBeOfNonNullableListType<Extended.TimeSpanGraphType>();
-            Type<NonNull<List<Id?>>>().ShouldBeOfNonNullableListType<IdGraphType>();
+            Type<NonNull<List<Id?>>>().ShouldBeOfNonNullableListType<Extended.IdGraphType>();
             Type<NonNull<List<Url>>>().ShouldBeOfNonNullableListType<Extended.UrlGraphType>();
             Type<NonNull<List<Uri>>>().ShouldBeOfNonNullableListType<UriGraphType>();
             Type<NonNull<List<Cursor?>>>().ShouldBeOfNonNullableListType<Extended.Relay.CursorGraphType>();
@@ -265,7 +265,7 @@ namespace Tests.Adapters
             Type<NonNull<List<DateTime>>>().ShouldBeOfNonNullableListType<NonNullGraphType<DateTimeGraphType>>();
             Type<NonNull<List<DateTimeOffset>>>().ShouldBeOfNonNullableListType<NonNullGraphType<DateTimeOffsetGraphType>>();
             Type<NonNull<List<TimeSpan>>>().ShouldBeOfNonNullableListType<NonNullGraphType<Extended.TimeSpanGraphType>>();
-            Type<NonNull<List<Id>>>().ShouldBeOfNonNullableListType<NonNullGraphType<IdGraphType>>();
+            Type<NonNull<List<Id>>>().ShouldBeOfNonNullableListType<NonNullGraphType<Extended.IdGraphType>>();
             Type<NonNull<List<NonNull<Url>>>>().ShouldBeOfNonNullableListType<NonNullGraphType<Extended.UrlGraphType>>();
             Type<NonNull<List<NonNull<Uri>>>>().ShouldBeOfNonNullableListType<NonNullGraphType<UriGraphType>>();
             Type<NonNull<List<Cursor>>>().ShouldBeOfNonNullableListType<NonNullGraphType<Extended.Relay.CursorGraphType>>();
@@ -341,7 +341,7 @@ namespace Tests.Adapters
             Type<Task<DateTime?>>().ShouldBeOfType<DateTimeGraphType>();
             Type<Task<DateTimeOffset?>>().ShouldBeOfType<DateTimeOffsetGraphType>();
             Type<Task<TimeSpan?>>().ShouldBeOfType<Extended.TimeSpanGraphType>();
-            Type<Task<Id?>>().ShouldBeOfType<IdGraphType>();
+            Type<Task<Id?>>().ShouldBeOfType<Extended.IdGraphType>();
             Type<Task<Url>>().ShouldBeOfType<Extended.UrlGraphType>();
             Type<Task<Uri>>().ShouldBeOfType<UriGraphType>();
             Type<Task<Cursor?>>().ShouldBeOfType<Extended.Relay.CursorGraphType>();
@@ -367,7 +367,7 @@ namespace Tests.Adapters
             Type<Task<DateTime>>().ShouldBeOfNonNullableType<DateTimeGraphType>();
             Type<Task<DateTimeOffset>>().ShouldBeOfNonNullableType<DateTimeOffsetGraphType>();
             Type<Task<TimeSpan>>().ShouldBeOfNonNullableType<Extended.TimeSpanGraphType>();
-            Type<Task<Id>>().ShouldBeOfNonNullableType<IdGraphType>();
+            Type<Task<Id>>().ShouldBeOfNonNullableType<Extended.IdGraphType>();
             Type<Task<NonNull<Url>>>().ShouldBeOfNonNullableType<Extended.UrlGraphType>();
             Type<Task<NonNull<Uri>>>().ShouldBeOfNonNullableType<UriGraphType>();
             Type<Task<Cursor>>().ShouldBeOfNonNullableType<Extended.Relay.CursorGraphType>();
@@ -443,7 +443,7 @@ namespace Tests.Adapters
             Type<Task<List<DateTime?>>>().ShouldBeOfListType<DateTimeGraphType>();
             Type<Task<List<DateTimeOffset?>>>().ShouldBeOfListType<DateTimeOffsetGraphType>();
             Type<Task<List<TimeSpan?>>>().ShouldBeOfListType<Extended.TimeSpanGraphType>();
-            Type<Task<List<Id?>>>().ShouldBeOfListType<IdGraphType>();
+            Type<Task<List<Id?>>>().ShouldBeOfListType<Extended.IdGraphType>();
             Type<Task<List<Url>>>().ShouldBeOfListType<Extended.UrlGraphType>();
             Type<Task<List<Uri>>>().ShouldBeOfListType<UriGraphType>();
             Type<Task<List<Cursor?>>>().ShouldBeOfListType<Extended.Relay.CursorGraphType>();
@@ -469,7 +469,7 @@ namespace Tests.Adapters
             Type<Task<List<DateTime>>>().ShouldBeOfListType<NonNullGraphType<DateTimeGraphType>>();
             Type<Task<List<DateTimeOffset>>>().ShouldBeOfListType<NonNullGraphType<DateTimeOffsetGraphType>>();
             Type<Task<List<TimeSpan>>>().ShouldBeOfListType<NonNullGraphType<Extended.TimeSpanGraphType>>();
-            Type<Task<List<Id>>>().ShouldBeOfListType<NonNullGraphType<IdGraphType>>();
+            Type<Task<List<Id>>>().ShouldBeOfListType<NonNullGraphType<Extended.IdGraphType>>();
             Type<Task<List<NonNull<Url>>>>().ShouldBeOfListType<NonNullGraphType<Extended.UrlGraphType>>();
             Type<Task<List<NonNull<Uri>>>>().ShouldBeOfListType<NonNullGraphType<UriGraphType>>();
             Type<Task<List<Cursor>>>().ShouldBeOfListType<NonNullGraphType<Extended.Relay.CursorGraphType>>();
@@ -545,7 +545,7 @@ namespace Tests.Adapters
             Type<Task<NonNull<List<DateTime?>>>>().ShouldBeOfNonNullableListType<DateTimeGraphType>();
             Type<Task<NonNull<List<DateTimeOffset?>>>>().ShouldBeOfNonNullableListType<DateTimeOffsetGraphType>();
             Type<Task<NonNull<List<TimeSpan?>>>>().ShouldBeOfNonNullableListType<Extended.TimeSpanGraphType>();
-            Type<Task<NonNull<List<Id?>>>>().ShouldBeOfNonNullableListType<IdGraphType>();
+            Type<Task<NonNull<List<Id?>>>>().ShouldBeOfNonNullableListType<Extended.IdGraphType>();
             Type<Task<NonNull<List<Url>>>>().ShouldBeOfNonNullableListType<Extended.UrlGraphType>();
             Type<Task<NonNull<List<Uri>>>>().ShouldBeOfNonNullableListType<UriGraphType>();
             Type<Task<NonNull<List<Cursor?>>>>().ShouldBeOfNonNullableListType<Extended.Relay.CursorGraphType>();
@@ -571,7 +571,7 @@ namespace Tests.Adapters
             Type<Task<NonNull<List<DateTime>>>>().ShouldBeOfNonNullableListType<NonNullGraphType<DateTimeGraphType>>();
             Type<Task<NonNull<List<DateTimeOffset>>>>().ShouldBeOfNonNullableListType<NonNullGraphType<DateTimeOffsetGraphType>>();
             Type<Task<NonNull<List<TimeSpan>>>>().ShouldBeOfNonNullableListType<NonNullGraphType<Extended.TimeSpanGraphType>>();
-            Type<Task<NonNull<List<Id>>>>().ShouldBeOfNonNullableListType<NonNullGraphType<IdGraphType>>();
+            Type<Task<NonNull<List<Id>>>>().ShouldBeOfNonNullableListType<NonNullGraphType<Extended.IdGraphType>>();
             Type<Task<NonNull<List<NonNull<Url>>>>>().ShouldBeOfNonNullableListType<NonNullGraphType<Extended.UrlGraphType>>();
             Type<Task<NonNull<List<NonNull<Uri>>>>>().ShouldBeOfNonNullableListType<NonNullGraphType<UriGraphType>>();
             Type<Task<NonNull<List<Cursor>>>>().ShouldBeOfNonNullableListType<NonNullGraphType<Extended.Relay.CursorGraphType>>();

--- a/test/GraphQL.Conventions.Tests/Adapters/Types/GuidGraphTypeTests.cs
+++ b/test/GraphQL.Conventions.Tests/Adapters/Types/GuidGraphTypeTests.cs
@@ -25,7 +25,7 @@ namespace Tests.Adapters.Types
         [Test]
         public override void Can_Parse_Literal()
         {
-            ShouldParseLiteral(new StringValue(null), null);
+            ShouldParseLiteral(new NullValue(), null);
             ShouldParseLiteral(new StringValue("ad9da688-1fd4-4e00-ad89-b4d3fef08280"), new Guid("ad9da688-1fd4-4e00-ad89-b4d3fef08280"));
             ShouldParseLiteral(new IntValue(0), null);
         }

--- a/test/GraphQL.Conventions.Tests/Adapters/Types/UriGraphTypeTests.cs
+++ b/test/GraphQL.Conventions.Tests/Adapters/Types/UriGraphTypeTests.cs
@@ -30,7 +30,7 @@ namespace Tests.Adapters.Types
         [Test]
         public override void Can_Parse_Literal()
         {
-            ShouldParseLiteral(new StringValue(null), null);
+            ShouldParseLiteral(new NullValue(), null);
             ShouldParseLiteral(new StringValue("http://www.google.com/"), new Uri("http://www.google.com/"));
             ShouldParseLiteral(new StringValue("mailto:someone@somewhere.com"), new Uri("mailto:someone@somewhere.com"));
             ShouldParseLiteral(new StringValue("\"http://www.google.com/\""), new Uri("http://www.google.com/"));

--- a/test/GraphQL.Conventions.Tests/Adapters/Types/UrlGraphTypeTests.cs
+++ b/test/GraphQL.Conventions.Tests/Adapters/Types/UrlGraphTypeTests.cs
@@ -30,7 +30,7 @@ namespace Tests.Adapters.Types
         [Test]
         public override void Can_Parse_Literal()
         {
-            ShouldParseLiteral(new StringValue(null), null);
+            ShouldParseLiteral(new NullValue(), null);
             ShouldParseLiteral(new StringValue("http://www.google.com/"), new Url("http://www.google.com/"));
             ShouldParseLiteral(new StringValue("mailto:someone@somewhere.com"), new Url("mailto:someone@somewhere.com"));
             ShouldParseLiteral(new StringValue("\"http://www.google.com/\""), new Url("http://www.google.com/"));

--- a/test/GraphQL.Conventions.Tests/Attributes/Execution/Relay/DynamicMutationRegistrationTests.cs
+++ b/test/GraphQL.Conventions.Tests/Attributes/Execution/Relay/DynamicMutationRegistrationTests.cs
@@ -3,6 +3,8 @@ using GraphQL.Conventions;
 using GraphQL.Conventions.Relay;
 using Tests.Templates;
 using Tests.Templates.Extensions;
+using Tests.Types;
+
 // ReSharper disable UnusedType.Local
 // ReSharper disable UnusedAutoPropertyAccessor.Local
 
@@ -30,7 +32,10 @@ namespace Tests.Attributes.Execution.Relay
                 typeof(SchemaDefinitionWithMutation<FooMutation>),
                 typeof(SchemaDefinitionWithMutation<BarMutation>),
             };
-            var engine = GraphQLEngine.New().BuildSchema(mutations);
+            var engine = GraphQLEngine.New()
+                .WithQuery<TestQuery>()
+                .BuildSchema(mutations);
+
             var result = await engine
                 .NewExecutor()
                 .WithQueryString(query)
@@ -103,6 +108,11 @@ namespace Tests.Attributes.Execution.Relay
         class BarOutput : RelayOutput
         {
             public int Result { get; set; }
+        }
+
+        class Query
+        {
+            public string Hello => "World";
         }
     }
 }

--- a/test/GraphQL.Conventions.Tests/Attributes/Execution/Relay/RelayMutationAttributeTests.cs
+++ b/test/GraphQL.Conventions.Tests/Attributes/Execution/Relay/RelayMutationAttributeTests.cs
@@ -3,8 +3,11 @@ using System.Threading.Tasks;
 using GraphQL;
 using GraphQL.Conventions;
 using GraphQL.Conventions.Relay;
+using Tests.Adapters.Engine;
 using Tests.Templates;
 using Tests.Templates.Extensions;
+using Tests.Types;
+
 // ReSharper disable UnusedMember.Local
 // ReSharper disable UnusedAutoPropertyAccessor.Local
 
@@ -106,7 +109,9 @@ namespace Tests.Attributes.Execution.Relay
         {
             var engine = GraphQLEngine
                 .New()
+                .WithQuery<TestQuery>()
                 .WithMutation<T>();
+
             var result = await engine
                 .NewExecutor()
                 .WithQueryString(query)

--- a/test/GraphQL.Conventions.Tests/GraphQL.Conventions.Tests.csproj
+++ b/test/GraphQL.Conventions.Tests/GraphQL.Conventions.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <StartupObject>Tests.Program</StartupObject>
     <RootNamespace>Tests</RootNamespace>
   </PropertyGroup>
@@ -12,12 +12,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.reporters" Version="2.3.1" />
-    <PackageReference Include="NSubstitute" Version="2.0.0-*" />
-    <PackageReference Include="ReportGenerator" Version="2.5.9" />
+    <PackageReference Include="GraphQL" Version="4.0.2" />
+    <PackageReference Include="GraphQL.DataLoader" Version="4.0.2" />
+    <PackageReference Include="GraphQL.SystemReactive" Version="4.0.2" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="16.9.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.reporters" Version="2.4.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="ReportGenerator" Version="4.8.7" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
   </ItemGroup>
 

--- a/test/GraphQL.Conventions.Tests/GraphQL.Conventions.Tests.csproj
+++ b/test/GraphQL.Conventions.Tests/GraphQL.Conventions.Tests.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL" Version="4.0.2" />
-    <PackageReference Include="GraphQL.DataLoader" Version="4.0.2" />
-    <PackageReference Include="GraphQL.SystemReactive" Version="4.0.2" />
+    <PackageReference Include="GraphQL" Version="4.1.0" />
+    <PackageReference Include="GraphQL.DataLoader" Version="4.1.0" />
+    <PackageReference Include="GraphQL.SystemReactive" Version="4.1.0" />
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="16.9.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/test/GraphQL.Conventions.Tests/Templates/Extensions/ConstructionTestExtensions.cs
+++ b/test/GraphQL.Conventions.Tests/Templates/Extensions/ConstructionTestExtensions.cs
@@ -97,13 +97,13 @@ namespace Tests.Templates.Extensions
             Assert.AreEqual(typeof(NonNullGraphType<ListGraphType<TType>>), type.GetType());
         }
 
-        public static void OfType<TType>(this IFieldType field)
+        public static void OfType<TType>(this FieldType field)
             where TType : GraphType
         {
             field.Type.ShouldBeOfType<TType>();
         }
 
-        public static void OfNonNullableType<TType>(this IFieldType field)
+        public static void OfNonNullableType<TType>(this FieldType field)
             where TType : GraphType
         {
             field.Type.ShouldBeOfNonNullableType<TType>();

--- a/test/GraphQL.Conventions.Tests/Types/TestQuery.cs
+++ b/test/GraphQL.Conventions.Tests/Types/TestQuery.cs
@@ -1,0 +1,7 @@
+namespace Tests.Types
+{
+    public class TestQuery
+    {
+        public string Hello => "World";
+    }
+}

--- a/test/GraphQL.Conventions.Tests/Web/RequestHandlerTests.cs
+++ b/test/GraphQL.Conventions.Tests/Web/RequestHandlerTests.cs
@@ -214,7 +214,7 @@ namespace Tests.Web
             public Unwanted.TestQuery2 Mars => new Unwanted.TestQuery2();
         }
     }
-    
+ 
     class SimpleQuery
     {
         public string Hello => "World";

--- a/test/GraphQL.Conventions.Tests/Web/ResponseTests.cs
+++ b/test/GraphQL.Conventions.Tests/Web/ResponseTests.cs
@@ -31,12 +31,11 @@ namespace Tests.Web
         }
 
         [Test]
-        public async void Can_Instantiate_Response_Object_With_Extra_Data()
+        public async void Can_Instantiate_Response_Object_With_No_Data()
         {
-            var request = Request.New("{\"query\":\"{}\"}");
+            var request = Request.New("{\"query\":\"{ }\"}");
             var result = new ExecutionResult
             {
-                Data = new Dictionary<string, object>(),
                 Extensions = new Dictionary<string, object>
                 {
                     { "trace", new
@@ -51,11 +50,11 @@ namespace Tests.Web
                 }
             };
             var response = new Response(request, result);
-            response.HasData.ShouldEqual(true);
+            response.HasData.ShouldEqual(false);
             response.HasErrors.ShouldEqual(false);
 
             var body = await response.GetBodyAsync();
-            body.ShouldEqual("{\"data\":{},\"extensions\":{\"trace\":{\"foo\":1,\"bar\":{\"baz\":\"hello\"}}}}");
+            body.ShouldEqual("{\"extensions\":{\"trace\":{\"foo\":1,\"bar\":{\"baz\":\"hello\"}}}}");
         }
     }
 }


### PR DESCRIPTION
Migrate GraphQL.Net to 4.1.0 (see https://graphql-dotnet.github.io/docs/migrations/migration4)

  - Add `IdGraphType` overload to handle string conversion
  - Check schema contains at least one query type
  - Ignore field of ignored type (set via `SchemaConstructor.IgnoreTypesFromNamespacesStartingWith`)
  - Fix tests