### PR TITLE
Add DataLoaderUnwrapper

### DIFF
--- a/src/GraphQL.Conventions/Attributes/Execution/Unwrappers/DataLoaderUnwrapper.cs
+++ b/src/GraphQL.Conventions/Attributes/Execution/Unwrappers/DataLoaderUnwrapper.cs
@@ -4,7 +4,7 @@ namespace GraphQL.Conventions.Attributes.Execution.Unwrappers
 {
     public class DataLoaderUnwrapper : UnwrapperBase
     {
-        private static readonly ValueUnwrapper _valueUnwrapper = new ValueUnwrapper();
+        private static readonly ValueUnwrapper Unwrapper = new ValueUnwrapper();
 
         public override object UnwrapValue(object value)
         {
@@ -13,7 +13,7 @@ namespace GraphQL.Conventions.Attributes.Execution.Unwrappers
                 return new SimpleDataLoader<object>(async cancellationToken =>
                 {
                     var result = await dataLoaderResult.GetResultAsync(cancellationToken).ConfigureAwait(false);
-                    return _valueUnwrapper.Unwrap(result);
+                    return Unwrapper.Unwrap(result);
                 });
             }
             else

--- a/src/GraphQL.Conventions/Attributes/Execution/Unwrappers/DataLoaderUnwrapper.cs
+++ b/src/GraphQL.Conventions/Attributes/Execution/Unwrappers/DataLoaderUnwrapper.cs
@@ -17,7 +17,9 @@ namespace GraphQL.Conventions.Attributes.Execution.Unwrappers
                 });
             }
             else
+            {
                 return value;
+            }
         }
     }
 }

--- a/src/GraphQL.Conventions/Attributes/Execution/Unwrappers/DataLoaderUnwrapper.cs
+++ b/src/GraphQL.Conventions/Attributes/Execution/Unwrappers/DataLoaderUnwrapper.cs
@@ -1,0 +1,23 @@
+using GraphQL.DataLoader;
+
+namespace GraphQL.Conventions.Attributes.Execution.Unwrappers
+{
+    public class DataLoaderUnwrapper : UnwrapperBase
+    {
+        private static readonly ValueUnwrapper _valueUnwrapper = new ValueUnwrapper();
+
+        public override object UnwrapValue(object value)
+        {
+            if (value is IDataLoaderResult dataLoaderResult)
+            {
+                return new SimpleDataLoader<object>(async cancellationToken =>
+                {
+                    var result = await dataLoaderResult.GetResultAsync(cancellationToken).ConfigureAwait(false);
+                    return _valueUnwrapper.Unwrap(result);
+                });
+            }
+            else
+                return value;
+        }
+    }
+}

--- a/src/GraphQL.Conventions/Attributes/Execution/Unwrappers/ValueUnwrapper.cs
+++ b/src/GraphQL.Conventions/Attributes/Execution/Unwrappers/ValueUnwrapper.cs
@@ -7,7 +7,8 @@ namespace GraphQL.Conventions.Attributes.Execution.Unwrappers
             this.Next(new NonNullUnwrapper())
                 .Next(new OptionalUnwrapper())
                 .Next(new UnionUnwrapper())
-                .Next(new CollectionUnwrapper(this));
+                .Next(new CollectionUnwrapper(this))
+                .Next(new DataLoaderUnwrapper());
         }
 
         public override object UnwrapValue(object value) => value;

--- a/test/GraphQL.Conventions.Tests/Execution/DataLoaderResultUnwrappingTests.cs
+++ b/test/GraphQL.Conventions.Tests/Execution/DataLoaderResultUnwrappingTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using GraphQL.Conventions;
 using GraphQL.DataLoader;
 using GraphQL.NewtonsoftJson;
@@ -13,7 +14,10 @@ namespace Tests.Execution
         {
             const string query = @"{
                 dataLoaderResult
+                nonNullDataLoaderResult
+                nonNullListDataLoaderResult
                 nestedDataLoaderResult
+                nestedNonNullDataLoaderResult
                 anEnum
                 nestedEnum
                 namedResult
@@ -41,7 +45,13 @@ namespace Tests.Execution
         {
             public IDataLoaderResult<string> DataLoaderResult() => new DataLoaderResult<string>("Test");
 
+            public IDataLoaderResult<NonNull<string>> NonNullDataLoaderResult() => new DataLoaderResult<NonNull<string>>("Test");
+
+            public IDataLoaderResult<NonNull<List<NonNull<string>>>> NonNullListDataLoaderResult() => new DataLoaderResult<NonNull<List<NonNull<string>>>>(new List<NonNull<string>>() { "Test" });
+
             public IDataLoaderResult<IDataLoaderResult<string>> NestedDataLoaderResult() => new DataLoaderResult<IDataLoaderResult<string>>(new DataLoaderResult<string>("Test"));
+
+            public IDataLoaderResult<IDataLoaderResult<NonNull<string>>> NestedNonNullDataLoaderResult() => new DataLoaderResult<IDataLoaderResult<NonNull<string>>>(new DataLoaderResult<NonNull<string>>("Test"));
 
             public IDataLoaderResult<BugReproQueryDataLoaderResultEnum> AnEnum() => new DataLoaderResult<BugReproQueryDataLoaderResultEnum>(BugReproQueryDataLoaderResultEnum.One);
 


### PR DESCRIPTION
Fixes #220 

For resolvers that return an `IDataLoaderResult`, this PR has the resolver wait until the data loader executes, and then unwraps the result.  It is recursive in that the result can return a data loader result, which is unwrapped when executed.  It does not affect when the data loader executes within the execution strategy.  It does create a couple allocations per data loader result.  