### PR TITLE
docs: update staled target framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,9 @@ Download and install the package from [NuGet](https://www.nuget.org/packages/Gra
 PS> Install-Package GraphQL.Conventions
 ```
 
-The following targets are available:
+This project targets [.NET Standard] 2.0.
 
- * .NET Framework 4.5
- * .NET Platform Standard 1.5
+[.NET Standard]: https://docs.microsoft.com/en-us/dotnet/standard/net-standard
 
 ## Getting Started
 


### PR DESCRIPTION
When the `README.md` file had introduced at f115b4fd96c24cb2df1b86200565e5d28d4afdb3, this project had targeted `netstandard1.5` and `net45` and the `README.md` had described it well.

This project has become to target only `netstandard2.0` since #194 but `README.md` shows staled target framework informations.
This pull request fixes such issue.