### PR TITLE
Added boolean to add compatibility with graphql-dotnet 4.6.1

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+	<packageSources>
+		<clear />
+		<add key="inrayProGet" value="https://inray-nuget/nuget/inray-nuget/v3/index.json" />
+		<add key="inrayAzure" value="https://pkgs.dev.azure.com/inray/_packaging/inray/nuget/v3/index.json" />
+		<add key="Conventions Local" value="D:\github\conventions\src\GraphQL.Conventions\bin\Debug" />
+
+		<add key="Gql Local" value="D:\github\graphql-dotnet\src\GraphQL\bin\Debug" />
+
+	</packageSources>
+
+</configuration>

--- a/src/GraphQL.Conventions/Adapters/Engine/GraphQLEngine.cs
+++ b/src/GraphQL.Conventions/Adapters/Engine/GraphQLEngine.cs
@@ -51,6 +51,7 @@ namespace GraphQL.Conventions
         private IErrorTransformation _errorTransformation = new DefaultErrorTransformation();
 
         private bool _includeFieldDescriptions;
+        private bool _throwUnhandledExceptions; 
 
         private bool _includeFieldDeprecationReasons;
 
@@ -208,6 +209,12 @@ namespace GraphQL.Conventions
             return this;
         }
 
+        public GraphQLEngine ThrowUnhandledExceptions(bool throwUnhandledExceptions = true)
+        {
+            _throwUnhandledExceptions = throwUnhandledExceptions;
+            return this;
+        }
+
         public GraphQLEngine PrintFieldDeprecationReasons(bool include = true)
         {
             _includeFieldDeprecationReasons = include;
@@ -297,12 +304,13 @@ namespace GraphQL.Conventions
                 EnableMetrics = enableProfiling,
                 UserContext = new Dictionary<string, object>()
                 {
-                    { typeof(IUserContext).FullName ?? nameof(IUserContext), userContext},
-                    { typeof(IDependencyInjector).FullName ?? nameof(IDependencyInjector), dependencyInjector},
+                    { typeof(IUserContext).FullName ?? nameof(IUserContext), userContext },
+                    { typeof(IDependencyInjector).FullName ?? nameof(IDependencyInjector), dependencyInjector },
                 },
                 ValidationRules = validationRules.Any() ? validationRules : null,
                 ComplexityConfiguration = complexityConfiguration,
                 CancellationToken = cancellationToken,
+                ThrowOnUnhandledException = _throwUnhandledExceptions,
             };
 
             if (listeners != null)

--- a/src/GraphQL.Conventions/Adapters/GraphTypeAdapter.cs
+++ b/src/GraphQL.Conventions/Adapters/GraphTypeAdapter.cs
@@ -41,7 +41,7 @@ namespace GraphQL.Conventions.Adapters
                 .GroupBy(t => t.Name)
                 .Select(g => g.First())
                 .ToArray();
-            var schema = new Schema(new FuncServiceProvider(DeriveTypeFromTypeInfo))
+            var schema = new Schema(new FuncServiceProvider(DeriveTypeFromTypeInfo), runConfigurations: false)
             {
                 Query = DeriveOperationType(schemaInfo.Query),
                 Mutation = DeriveOperationType(schemaInfo.Mutation),

--- a/src/GraphQL.Conventions/GraphQL.Conventions.csproj
+++ b/src/GraphQL.Conventions/GraphQL.Conventions.csproj
@@ -29,10 +29,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL" Version="4.1.0" />
-    <PackageReference Include="GraphQL.DataLoader" Version="4.1.0" />
-    <PackageReference Include="GraphQL.NewtonsoftJson" Version="4.1.0" />
-    <PackageReference Include="GraphQL.SystemReactive" Version="4.1.0" />
+    <PackageReference Include="GraphQL" Version="4.6.1" />
+    <PackageReference Include="GraphQL.DataLoader" Version="4.6.1" />
+    <PackageReference Include="GraphQL.NewtonsoftJson" Version="4.6.1" />
+    <PackageReference Include="GraphQL.SystemReactive" Version="4.6.1" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />


### PR DESCRIPTION
This pull requests is a work around to skip the creation of an IConfigureSchema instance (which is an interface).  

I was not able to register this on my side. Even when adding `services.AddGraphql().ConfigureSchema((schema) => {})` an error would be thrown preventing the graphql engine to start. 