### PR TITLE
Added boolean argument to add compatibility with graphql-dotnet 4.6.1

### DIFF
--- a/src/GraphQL.Conventions/Adapters/GraphTypeAdapter.cs
+++ b/src/GraphQL.Conventions/Adapters/GraphTypeAdapter.cs
@@ -41,7 +41,7 @@ namespace GraphQL.Conventions.Adapters
                 .GroupBy(t => t.Name)
                 .Select(g => g.First())
                 .ToArray();
-            var schema = new Schema(new FuncServiceProvider(DeriveTypeFromTypeInfo))
+            var schema = new Schema(new FuncServiceProvider(DeriveTypeFromTypeInfo), false)
             {
                 Query = DeriveOperationType(schemaInfo.Query),
                 Mutation = DeriveOperationType(schemaInfo.Mutation),

--- a/src/GraphQL.Conventions/GraphQL.Conventions.csproj
+++ b/src/GraphQL.Conventions/GraphQL.Conventions.csproj
@@ -29,10 +29,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL" Version="4.1.0" />
-    <PackageReference Include="GraphQL.DataLoader" Version="4.1.0" />
-    <PackageReference Include="GraphQL.NewtonsoftJson" Version="4.1.0" />
-    <PackageReference Include="GraphQL.SystemReactive" Version="4.1.0" />
+    <PackageReference Include="GraphQL" Version="4.6.1" />
+    <PackageReference Include="GraphQL.DataLoader" Version="4.6.1" />
+    <PackageReference Include="GraphQL.NewtonsoftJson" Version="4.6.1" />
+    <PackageReference Include="GraphQL.SystemReactive" Version="4.6.1" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />


### PR DESCRIPTION
This pull requests is a work around to skip the creation of an IConfigureSchema instance (which is an interface).

I was not able to register this on my side. Even when adding services.AddGraphql().ConfigureSchema((schema) => {}) an error would be thrown preventing the graphql engine to start.