### PR TITLE
Return null for interfaces in DeriveTypeFromTypeInfo

### DIFF
--- a/src/GraphQL.Conventions/Adapters/GraphTypeAdapter.cs
+++ b/src/GraphQL.Conventions/Adapters/GraphTypeAdapter.cs
@@ -73,7 +73,7 @@ namespace GraphQL.Conventions.Adapters
             {
                 return graphType;
             }
-            return Activator.CreateInstance(type);
+            return type.IsInterface ? null : Activator.CreateInstance(type);
         }
 
         private IObjectGraphType DeriveOperationType(GraphTypeInfo typeInfo) =>


### PR DESCRIPTION
- Fixes compatibility with GraphQL.NET 4.6.0+
- Alternative to #227 