### PR TITLE
Fix uniqueness of constructed graph types

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 7.0.x
           source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,10 +1,6 @@
 name: Check formatting
 
-on:
-  pull_request:
-    branches:
-      - master
-      - develop
+on: [pull_request]
 
 env:
   DOTNET_NOLOGO: true
@@ -19,7 +15,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 7.0.x
           source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 7.0.x
           source-url: https://api.nuget.org/v3/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.CONV_NUGET_AUTH_TOKEN}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 7.0.x
           source-url: https://nuget.pkg.github.com/graphql-dotnet/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/Conventions.sln
+++ b/Conventions.sln
@@ -41,6 +41,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples' Tests", "Samples' 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SubscriptionExample.Tests", "test\SubscriptionExample.Tests\SubscriptionExample.Tests.csproj", "{0BDE134F-0332-4D46-B762-DC861B6B126D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleWebApp.Tests", "samples\SimpleWebApp.Tests\SimpleWebApp.Tests.csproj", "{70202B0F-F2E3-470D-AE0F-B2F5966E4B19}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -123,6 +125,18 @@ Global
 		{0BDE134F-0332-4D46-B762-DC861B6B126D}.Release|x64.Build.0 = Release|Any CPU
 		{0BDE134F-0332-4D46-B762-DC861B6B126D}.Release|x86.ActiveCfg = Release|Any CPU
 		{0BDE134F-0332-4D46-B762-DC861B6B126D}.Release|x86.Build.0 = Release|Any CPU
+		{70202B0F-F2E3-470D-AE0F-B2F5966E4B19}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{70202B0F-F2E3-470D-AE0F-B2F5966E4B19}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{70202B0F-F2E3-470D-AE0F-B2F5966E4B19}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{70202B0F-F2E3-470D-AE0F-B2F5966E4B19}.Debug|x64.Build.0 = Debug|Any CPU
+		{70202B0F-F2E3-470D-AE0F-B2F5966E4B19}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{70202B0F-F2E3-470D-AE0F-B2F5966E4B19}.Debug|x86.Build.0 = Debug|Any CPU
+		{70202B0F-F2E3-470D-AE0F-B2F5966E4B19}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{70202B0F-F2E3-470D-AE0F-B2F5966E4B19}.Release|Any CPU.Build.0 = Release|Any CPU
+		{70202B0F-F2E3-470D-AE0F-B2F5966E4B19}.Release|x64.ActiveCfg = Release|Any CPU
+		{70202B0F-F2E3-470D-AE0F-B2F5966E4B19}.Release|x64.Build.0 = Release|Any CPU
+		{70202B0F-F2E3-470D-AE0F-B2F5966E4B19}.Release|x86.ActiveCfg = Release|Any CPU
+		{70202B0F-F2E3-470D-AE0F-B2F5966E4B19}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -133,6 +147,7 @@ Global
 		{E7DA8A82-3914-41E5-B5BE-D0BB3F234CE3} = {117AB27B-C4F4-4072-A857-4D2B868BEB80}
 		{67DFCB1B-6331-41E5-8FD3-03964526EDDD} = {60A6D426-6E98-45CA-B5C4-59B27C4EFD81}
 		{0BDE134F-0332-4D46-B762-DC861B6B126D} = {F9132124-0747-427F-B607-B7BAD25332F7}
+		{70202B0F-F2E3-470D-AE0F-B2F5966E4B19} = {F9132124-0747-427F-B607-B7BAD25332F7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BBCC6FB7-C0AE-43E0-866B-CA12D6D121DC}

--- a/samples/SimpleWebApp.Tests/EndToEndTests.cs
+++ b/samples/SimpleWebApp.Tests/EndToEndTests.cs
@@ -1,0 +1,94 @@
+using System.Net;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+
+namespace SimpleWebApp.Tests;
+
+public class EndToEndTests
+{
+    [Fact]
+    public async Task Search()
+    {
+        var query = """
+            {
+              search (forString:"") {
+                items {
+                  __typename
+                  ... on Book {
+                    id
+                    title
+                  }
+                  ... on Author {
+                    id
+                    firstName
+                    lastName
+                  }
+                }
+              }
+            }
+            """;
+
+        var expected = """
+            {
+              "data": {
+                "search": {
+                  "items": [
+                    {
+                      "__typename": "Book",
+                      "id": "Qm9vazox",
+                      "title": "A Lone Wolf in the Forest"
+                    },
+                    {
+                      "__typename": "Book",
+                      "id": "Qm9vazoy",
+                      "title": "Surfer Boy"
+                    },
+                    {
+                      "__typename": "Book",
+                      "id": "Qm9vazoz",
+                      "title": "GraphQL, a Love Story"
+                    },
+                    {
+                      "__typename": "Book",
+                      "id": "Qm9vazo0",
+                      "title": "Dare I Say What?"
+                    },
+                    {
+                      "__typename": "Author",
+                      "id": "QXV0aG9yOjE=",
+                      "firstName": "Benny",
+                      "lastName": "Frank"
+                    }
+                  ]
+                }
+              }
+            }
+            """;
+
+        using var webApp = new WebApplicationFactory<GraphQL.Conventions.Tests.Server.Program>();
+        using var server = webApp.Server;
+        server.AllowSynchronousIO = true; // for Newtonsoft.Json support
+        await VerifyGraphQLPostAsync(server, "/graphql", query, expected).ConfigureAwait(false);
+    }
+
+    private static async Task VerifyGraphQLPostAsync(
+        TestServer server,
+        string url,
+        string query,
+        string expected,
+        HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        using var client = server.CreateClient();
+        var body = JsonSerializer.Serialize(new { query });
+        var content = new StringContent(body, System.Text.Encoding.UTF8, "application/json");
+        using var request = new HttpRequestMessage(HttpMethod.Post, url);
+        request.Content = content;
+        using var response = await client.SendAsync(request).ConfigureAwait(false);
+        Assert.Equal(statusCode, response.StatusCode);
+        var ret = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        var jsonExpected = JsonSerializer.Serialize(JsonSerializer.Deserialize<JsonElement>(expected));
+        var jsonActual = JsonSerializer.Serialize(JsonSerializer.Deserialize<JsonElement>(ret));
+        Assert.Equal(jsonExpected, jsonActual);
+    }
+}

--- a/samples/SimpleWebApp.Tests/SimpleWebApp.Tests.csproj
+++ b/samples/SimpleWebApp.Tests/SimpleWebApp.Tests.csproj
@@ -1,28 +1,27 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
 
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.*" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SimpleWebApp\SimpleWebApp.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\SimpleWebApp\SimpleWebApp.csproj" />
-    </ItemGroup>
-
+  <ItemGroup>
+    <Using Include="Xunit"/>
+  </ItemGroup>
 </Project>

--- a/samples/SimpleWebApp.Tests/SimpleWebApp.Tests.csproj
+++ b/samples/SimpleWebApp.Tests/SimpleWebApp.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\SimpleWebApp\SimpleWebApp.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/samples/SimpleWebApp.Tests/SimpleWebAppUnitTests.cs
+++ b/samples/SimpleWebApp.Tests/SimpleWebAppUnitTests.cs
@@ -1,0 +1,30 @@
+using GraphQL.Conventions;
+using GraphQL.Conventions.Tests.Server;
+using GraphQL.Conventions.Tests.Server.Data.Repositories;
+using GraphQL.Conventions.Tests.Server.Schema;
+using GraphQL.Conventions.Web;
+
+namespace SimpleWebApp.Tests;
+
+public class SimpleWebAppSchemaCreationTests
+{
+    [Fact]
+    public async Task TestSimpleWebAppAsync()
+    {
+        var dependencyInjector = new DependencyInjector();
+        dependencyInjector.Register<IBookRepository>(new BookRepository());
+        dependencyInjector.Register<IAuthorRepository>(new AuthorRepository());
+
+        var requestHandler = RequestHandler
+            .New()
+            .WithDependencyInjector(dependencyInjector)
+            .WithQueryAndMutation<Query, Mutation>()
+            .Generate();
+
+        var request = Request.New(new QueryInput { QueryString = "{ __schema { types { name } } }" });
+        var result = await requestHandler.ProcessRequestAsync(request, null, dependencyInjector);
+
+        Assert.False(result.HasErrors);
+        Assert.True(result.IsValid);
+    }
+}

--- a/samples/SimpleWebApp.Tests/Usings.cs
+++ b/samples/SimpleWebApp.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/samples/SimpleWebApp.Tests/Usings.cs
+++ b/samples/SimpleWebApp.Tests/Usings.cs
@@ -1,1 +1,0 @@
-global using Xunit;

--- a/samples/SimpleWebApp/Program.cs
+++ b/samples/SimpleWebApp/Program.cs
@@ -1,5 +1,5 @@
-using System.IO;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace GraphQL.Conventions.Tests.Server
@@ -8,15 +8,16 @@ namespace GraphQL.Conventions.Tests.Server
     {
         public static void Main(string[] args)
         {
-            var host = new WebHostBuilder()
-                .UseKestrel(options => options.AllowSynchronousIO = true) // for Newtonsoft.Json support
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .UseIISIntegration()
-                .UseStartup<Startup>()
-                .ConfigureLogging(l => l.AddConsole())
-                .Build();
+            var host = CreateHostBuilder(args).Build();
 
             host.Run();
         }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) => Host
+            .CreateDefaultBuilder(args)
+            .ConfigureWebHostDefaults(webBuilder => webBuilder
+                .UseStartup<Startup>()
+                .ConfigureKestrel(options => options.AllowSynchronousIO = true)) // for Newtonsoft.Json support
+            .ConfigureLogging(l => l.AddConsole());
     }
 }

--- a/samples/SimpleWebApp/SimpleWebApp.csproj
+++ b/samples/SimpleWebApp/SimpleWebApp.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <RootNamespace>GraphQL.Conventions.Tests.Server</RootNamespace>
   </PropertyGroup>

--- a/src/GraphQL.Conventions/CommonAssemblyInfo.cs
+++ b/src/GraphQL.Conventions/CommonAssemblyInfo.cs
@@ -8,8 +8,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright("Copyright 2016-2022 Tommy Lillehagen. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("7.0.0")]
-[assembly: AssemblyInformationalVersion("7.0.0")]
+[assembly: AssemblyFileVersion("7.2.0")]
+[assembly: AssemblyInformationalVersion("7.2.0")]
 [assembly: CLSCompliant(false)]
 
 [assembly: InternalsVisibleTo("Tests")]

--- a/src/GraphQL.Conventions/GraphQL.Conventions.csproj
+++ b/src/GraphQL.Conventions/GraphQL.Conventions.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <Description>GraphQL Conventions for .NET</Description>
-    <VersionPrefix>7.1.0</VersionPrefix>
-    <PackageVersion>7.1.0</PackageVersion>
+    <VersionPrefix>7.2.0</VersionPrefix>
+    <PackageVersion>7.2.0</PackageVersion>
     <Authors>Tommy Lillehagen</Authors>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>

--- a/src/GraphQL.Conventions/Types/Descriptors/GraphTypeInfo.cs
+++ b/src/GraphQL.Conventions/Types/Descriptors/GraphTypeInfo.cs
@@ -18,6 +18,15 @@ namespace GraphQL.Conventions.Types.Descriptors
             DeriveMetaData();
         }
 
+        public string QualifiedName
+        {
+            get
+            {
+                string name = IsListType ? $"[{TypeParameter.QualifiedName}]" : Name;
+                return IsNullable ? name : $"{name}!";
+            }
+        }
+
         public bool IsRegisteredType { get; set; }
 
         public bool IsPrimitive { get; set; }

--- a/test/SubscriptionExample.Tests/EndToEndTests.cs
+++ b/test/SubscriptionExample.Tests/EndToEndTests.cs
@@ -124,7 +124,7 @@ public class EndToEndTests
         };
 
         using var webApp = new WebApplicationFactory<Program>();
-        var server = webApp.Server;
+        using var server = webApp.Server;
         var websocketTask = VerifyGraphQLWebSocketsAsync(server, querySubscription, expectedSubscription);
         await VerifyGraphQLPostAsync(server, query: query1, expected: expected1).ConfigureAwait(false);
         await VerifyGraphQLPostAsync(server, query: query2, expected: expected2).ConfigureAwait(false);

--- a/test/SubscriptionExample.Tests/SubscriptionExample.Tests.csproj
+++ b/test/SubscriptionExample.Tests/SubscriptionExample.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
@@ -14,7 +14,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.*" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.*" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
As discovered in #237, and after the addition of integrity checks in the parent library (graphql-dotnet/graphql-dotnet#3332), the Convention library has been shown to create duplicate instances of derived graph types in some cases due to insufficient caching logic.

Previously, this didn't flag since there were no integrity checks to look for this kind of behaviour. The types are derived deterministically, so although this miss caused usage with the latest version of the library to bark on query execution, there should be no logical changes in the way schemas are derived and evaluated (bar not triggering an error, obviously!) with this change.