### PR TITLE
Fix versioning for beta builds

### DIFF
--- a/src/GraphQL.Conventions/GraphQL.Conventions.csproj
+++ b/src/GraphQL.Conventions/GraphQL.Conventions.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <Description>GraphQL Conventions for .NET</Description>
     <VersionPrefix>7.2.0</VersionPrefix>
-    <PackageVersion>7.2.0</PackageVersion>
     <Authors>Tommy Lillehagen</Authors>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>

--- a/src/GraphQL.Conventions/GraphQL.Conventions.csproj
+++ b/src/GraphQL.Conventions/GraphQL.Conventions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>GraphQL Conventions for .NET</Description>
-    <VersionPrefix>7.2.0</VersionPrefix>
+    <VersionPrefix>7.2.0-preview</VersionPrefix>
     <Authors>Tommy Lillehagen</Authors>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>


### PR DESCRIPTION
This link here:

https://github.com/graphql-dotnet/conventions/pkgs/nuget/GraphQL.Conventions

should have versions such as 7.2.0-preview-124 where the suffix increments for each build (each merged PR) so there are no duplicates, and so it does not match versions published to nuget.org.  Compare to the main project here:

https://github.com/graphql-dotnet/graphql-dotnet/pkgs/nuget/GraphQL

This PR fixes that issue.  It will not affect published builds.