### PR TITLE
Move namespace of AddConventionsSchema

### DIFF
--- a/samples/SimpleWebApp/Program.cs
+++ b/samples/SimpleWebApp/Program.cs
@@ -1,5 +1,4 @@
 using GraphQL;
-using GraphQL.Conventions;
 using GraphQL.Conventions.Tests.Server;
 using GraphQL.Conventions.Tests.Server.Data.Repositories;
 using GraphQL.Conventions.Tests.Server.Schema;

--- a/src/GraphQL.Conventions/Extensions/GraphQLBuilderExtensions.cs
+++ b/src/GraphQL.Conventions/Extensions/GraphQLBuilderExtensions.cs
@@ -2,9 +2,10 @@
 
 using System;
 using System.Collections.Generic;
+using GraphQL.Conventions;
 using GraphQL.DI;
 
-namespace GraphQL.Conventions
+namespace GraphQL
 {
     public static class GraphQLBuilderExtensions
     {

--- a/tests/GraphQL.Conventions.Tests/GraphQL.Conventions.Tests.csproj
+++ b/tests/GraphQL.Conventions.Tests/GraphQL.Conventions.Tests.csproj
@@ -13,6 +13,9 @@
 
   <ItemGroup>
     <PackageReference Include="GraphQL.DataLoader" Version="7.2.1" />
+    <PackageReference Include="GraphQL.MicrosoftDI" Version="7.2.1" />
+    <PackageReference Include="GraphQL.SystemTextJson" Version="7.2.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="17.4.1" />
     <PackageReference Include="System.Reactive" Version="5.0.0" />

--- a/tests/GraphQL.Conventions.Tests/Web/GraphQLBuilderTests.cs
+++ b/tests/GraphQL.Conventions.Tests/Web/GraphQLBuilderTests.cs
@@ -30,6 +30,7 @@ namespace Tests.Web
             var serializer = services.GetRequiredService<IGraphQLTextSerializer>();
             var body = serializer.Serialize(result);
             Assert.AreEqual("{\"data\":{\"hello\":\"World\"}}", body);
+            // also ensure that configurations through ConfigureSchema run exactly one time
             Assert.AreEqual(1, schemaRunCount);
         }
 

--- a/tests/GraphQL.Conventions.Tests/Web/GraphQLBuilderTests.cs
+++ b/tests/GraphQL.Conventions.Tests/Web/GraphQLBuilderTests.cs
@@ -1,0 +1,41 @@
+using System.Threading.Tasks;
+using GraphQL;
+using GraphQL.Conventions;
+using GraphQL.Types;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Tests.Web
+{
+    public class GraphQLBuilderTests
+    {
+        [Test]
+        public async Task Can_Run_Query()
+        {
+            int schemaRunCount = 0;
+
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddGraphQL(b => b
+                .AddConventionsSchema<TestQuery>()
+                .AddSystemTextJson()
+                .ConfigureSchema(_ => schemaRunCount++));
+
+            var services = serviceCollection.BuildServiceProvider();
+
+            var executer = services.GetRequiredService<IDocumentExecuter<ISchema>>();
+            var result = await executer.ExecuteAsync(new ExecutionOptions
+            {
+                Query = "{ hello }",
+                RequestServices = services,
+            });
+            var serializer = services.GetRequiredService<IGraphQLTextSerializer>();
+            var body = serializer.Serialize(result);
+            Assert.AreEqual("{\"data\":{\"hello\":\"World\"}}", body);
+            Assert.AreEqual(1, schemaRunCount);
+        }
+
+        private class TestQuery
+        {
+            public string Hello => "World";
+        }
+    }
+}

--- a/tests/SimpleWebApp.Tests/SimpleWebAppUnitTests.cs
+++ b/tests/SimpleWebApp.Tests/SimpleWebAppUnitTests.cs
@@ -14,7 +14,7 @@ public class SimpleWebAppSchemaCreationTests
         var services = new ServiceCollection();
         services.AddSingleton<IBookRepository>(new BookRepository());
         services.AddSingleton<IAuthorRepository>(new AuthorRepository());
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
 
         var requestHandler = RequestHandler
             .New()
@@ -35,7 +35,7 @@ public class SimpleWebAppSchemaCreationTests
         var services = new ServiceCollection();
         services.AddSingleton<IBookRepository>(new BookRepository());
         services.AddSingleton<IAuthorRepository>(new AuthorRepository());
-        var serviceProvider = services.BuildServiceProvider();
+        using var serviceProvider = services.BuildServiceProvider();
 
         var schema = GraphQLEngine
             .New()


### PR DESCRIPTION
>  Remember that by convention (😄 ) all extension methods on `IGraphQLBuilder` live in `GraphQL` root namespace.

_Originally posted by @sungam3r in https://github.com/graphql-dotnet/conventions/pull/249#discussion_r1059396200_
      
Also: add a test to ensure that ConfigureSchema only runs once