### PR TITLE
Enhance enumerable graph type determing

### DIFF
--- a/src/GraphQL.Conventions/Types/Resolution/Extensions/ReflectionExtensions.cs
+++ b/src/GraphQL.Conventions/Types/Resolution/Extensions/ReflectionExtensions.cs
@@ -49,8 +49,8 @@ namespace GraphQL.Conventions.Types.Resolution.Extensions
 
                 for (int i = 0; i < interfaces.Length; i++)
                 {
-                    var @interface = mayFusedGenericInterface[i];
-                    if (@interface == interfaceType)
+                    var @interface = interfaces[i];
+                    if (mayFusedGenericInterface[i] == interfaceType)
                         return interfaces[i];
                     var ni = @interface.GetImplementInterface(interfaceType, fuseGeneric);
                     if (ni is not null)

--- a/src/GraphQL.Conventions/Types/Resolution/Extensions/ReflectionExtensions.cs
+++ b/src/GraphQL.Conventions/Types/Resolution/Extensions/ReflectionExtensions.cs
@@ -110,7 +110,7 @@ namespace GraphQL.Conventions.Types.Resolution.Extensions
                 return false;
             }
             return type.ImplementInterface(typeof(ICollection<>)) ||
-                   type.ImplementInterface(typeof(IReadOnlyCollection<>), true) ||
+                   type.ImplementInterface(typeof(IReadOnlyCollection<>)) ||
                    type.IsGenericType(typeof(IEnumerable<>)) ||
                    (type.IsGenericType && type.DeclaringType == typeof(Enumerable)) || // Handles internal Iterator implementations for LINQ; for reference https://referencesource.microsoft.com/#system.core/System/Linq/Enumerable.cs
                    type.IsArray;

--- a/src/GraphQL.Conventions/Types/Resolution/Extensions/ReflectionExtensions.cs
+++ b/src/GraphQL.Conventions/Types/Resolution/Extensions/ReflectionExtensions.cs
@@ -33,6 +33,11 @@ namespace GraphQL.Conventions.Types.Resolution.Extensions
         public static Type GetImplementInterface(this Type type, Type interfaceType, bool fuseGeneric = true)
         {
             if (!interfaceType.IsInterface) return null;
+            fuseGeneric &= interfaceType.IsGenericType;
+            if (type.IsGenericType && fuseGeneric
+                    ? type.GetGenericTypeDefinition() == interfaceType.GetGenericTypeDefinition()
+                    : type == interfaceType
+               ) return interfaceType;
             while (type is not null)
             {
                 var interfaces = type.GetInterfaces();

--- a/src/GraphQL.Conventions/Types/Resolution/Extensions/ReflectionExtensions.cs
+++ b/src/GraphQL.Conventions/Types/Resolution/Extensions/ReflectionExtensions.cs
@@ -105,6 +105,10 @@ namespace GraphQL.Conventions.Types.Resolution.Extensions
 
         public static bool IsEnumerableGraphType(this TypeInfo type)
         {
+            if (type.ImplementInterface(typeof(IDictionary)) || type.ImplementInterface(typeof(IDictionary<,>)))
+            {
+                return false;
+            }
             return type.ImplementInterface(typeof(ICollection<>)) ||
                    type.ImplementInterface(typeof(IReadOnlyCollection<>), true) ||
                    type.IsGenericType(typeof(IEnumerable<>)) ||

--- a/src/GraphQL.Conventions/Types/Resolution/Extensions/ReflectionExtensions.cs
+++ b/src/GraphQL.Conventions/Types/Resolution/Extensions/ReflectionExtensions.cs
@@ -32,12 +32,14 @@ namespace GraphQL.Conventions.Types.Resolution.Extensions
 
         public static Type GetImplementInterface(this Type type, Type interfaceType, bool fuseGeneric = true)
         {
-            if (!interfaceType.IsInterface) return null;
+            if (!interfaceType.IsInterface)
+                return null;
             fuseGeneric &= interfaceType.IsGenericType;
             if (type.IsGenericType && fuseGeneric
                     ? type.GetGenericTypeDefinition() == interfaceType.GetGenericTypeDefinition()
                     : type == interfaceType
-               ) return interfaceType;
+               )
+                return interfaceType;
             while (type is not null)
             {
                 var interfaces = type.GetInterfaces();
@@ -48,9 +50,11 @@ namespace GraphQL.Conventions.Types.Resolution.Extensions
                 for (int i = 0; i < interfaces.Length; i++)
                 {
                     var @interface = mayFusedGenericInterface[i];
-                    if (@interface == interfaceType) return interfaces[i];
+                    if (@interface == interfaceType)
+                        return interfaces[i];
                     var ni = @interface.GetImplementInterface(interfaceType, fuseGeneric);
-                    if (ni is not null) return ni;
+                    if (ni is not null)
+                        return ni;
                 }
 
                 type = type.BaseType;

--- a/test/GraphQL.Conventions.Tests/Types/Resolution/Extensions/ReflectionExtensionsTests.cs
+++ b/test/GraphQL.Conventions.Tests/Types/Resolution/Extensions/ReflectionExtensionsTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
@@ -10,13 +11,13 @@ namespace Tests.Types.Resolution.Extensions
     public class ReflectionExtensionsTests
     {
         [Theory]
-        [MemberData(nameof(IsEnumerableGraphType_Should_ReturnTrue_For_Common_Collection_Types__Data))]
-        public void IsEnumerableGraphType_Should_ReturnTrue_For_Common_Collection_Types(Type type)
+        [MemberData(nameof(IsEnumerableGraphType_Should_Return_True_For_Common_Collection_Types_Data))]
+        public void IsEnumerableGraphType_Should_Return_True_For_Common_Collection_Types(Type type)
         {
             Assert.IsTrue(type.GetTypeInfo().IsEnumerableGraphType());
         }
 
-        public static TheoryData<Type> IsEnumerableGraphType_Should_ReturnTrue_For_Common_Collection_Types__Data() => new()
+        public static TheoryData<Type> IsEnumerableGraphType_Should_Return_True_For_Common_Collection_Types_Data() => new()
         {
             typeof(IEnumerable<>),
             typeof(ConcurrentQueue<>),
@@ -25,15 +26,28 @@ namespace Tests.Types.Resolution.Extensions
             typeof(List<>),
             typeof(IList<>),
             typeof(IReadOnlyList<>),
-            typeof(IReadOnlyCollection<>)
+            typeof(IReadOnlyCollection<>),
         };
 
         [Theory]
-        [MemberData(nameof(GetImplementInterface_WithoutFuse_AcquireSpecifyInterfaceOnly__Data))]
-        public void GetImplementInterface_WithoutFuse_AcquireSpecifyInterfaceOnly(Type type, Type assignableInterface)
-            => Assert.IsTrue(type.ImplementInterface(assignableInterface, false));
+        [MemberData(nameof(IsEnumerableGraphType_Should_Return_False_For_Common_Dictionary_Types_Data))]
+        public void IsEnumerableGraphType_Should_Return_False_For_Common_Dictionary_Types(Type type)
+        {
+            Assert.IsFalse(type.GetTypeInfo().IsEnumerableGraphType());
+        }
 
-        public static TheoryData<Type, Type> GetImplementInterface_WithoutFuse_AcquireSpecifyInterfaceOnly__Data() =>
+        public static TheoryData<Type> IsEnumerableGraphType_Should_Return_False_For_Common_Dictionary_Types_Data() => new()
+        {
+            typeof(IDictionary<,>),
+            typeof(IDictionary),
+        };
+
+        [Theory]
+        [MemberData(nameof(GetImplementationInterface_WithoutFuse_AcquireSpecifiedInterfaceOnly_Data))]
+        public void GetImplementationInterface_WithoutFuse_AcquireSpecifiedInterfaceOnly(Type type, Type assignableInterface)
+            => Assert.IsTrue(type.IsImplementingInterface(assignableInterface, false));
+
+        public static TheoryData<Type, Type> GetImplementationInterface_WithoutFuse_AcquireSpecifiedInterfaceOnly_Data() =>
             new()
             {
                 { typeof(ITestInterface1<int>), typeof(ITestInterface1<int>) },
@@ -48,11 +62,11 @@ namespace Tests.Types.Resolution.Extensions
             };
 
         [Theory]
-        [MemberData(nameof(GetImplementInterface_WithFuse_AcquireSpecifyInterfaceOnly__Data))]
-        public void GetImplementInterface_WithFuse_AcquireSpecifyInterfaceOnly(Type type, Type assignableInterface) =>
-            Assert.IsTrue(type.ImplementInterface(assignableInterface));
+        [MemberData(nameof(GetImplementationInterface_WithFuse_AcquireSpecifiedInterfaceOnly_Data))]
+        public void GetImplementationInterface_WithFuse_AcquireSpecifiedInterfaceOnly(Type type, Type assignableInterface) =>
+            Assert.IsTrue(type.IsImplementingInterface(assignableInterface));
 
-        public static TheoryData<Type, Type> GetImplementInterface_WithFuse_AcquireSpecifyInterfaceOnly__Data() =>
+        public static TheoryData<Type, Type> GetImplementationInterface_WithFuse_AcquireSpecifiedInterfaceOnly_Data() =>
             new()
             {
                 { typeof(ITestInterface1<int>), typeof(ITestInterface1<>) },

--- a/test/GraphQL.Conventions.Tests/Types/Resolution/Extensions/ReflectionExtensionsTests.cs
+++ b/test/GraphQL.Conventions.Tests/Types/Resolution/Extensions/ReflectionExtensionsTests.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
 using GraphQL.Conventions.Types.Resolution.Extensions;
 using Xunit;
 
@@ -6,6 +9,25 @@ namespace Tests.Types.Resolution.Extensions
 {
     public class ReflectionExtensionsTests
     {
+        [Theory]
+        [MemberData(nameof(IsEnumerableGraphType_Should_ReturnTrue_For_Common_Collection_Types__Data))]
+        public void IsEnumerableGraphType_Should_ReturnTrue_For_Common_Collection_Types(Type type)
+        {
+            Assert.IsTrue(type.GetTypeInfo().IsEnumerableGraphType());
+        }
+
+        public static TheoryData<Type> IsEnumerableGraphType_Should_ReturnTrue_For_Common_Collection_Types__Data() => new()
+        {
+            typeof(IEnumerable<>),
+            typeof(ConcurrentQueue<>),
+            typeof(HashSet<>),
+            typeof(int[]),
+            typeof(List<>),
+            typeof(IList<>),
+            typeof(IReadOnlyList<>),
+            typeof(IReadOnlyCollection<>)
+        };
+
         [Theory]
         [MemberData(nameof(GetImplementInterface_WithoutFuse_AcquireSpecifyInterfaceOnly__Data))]
         public void GetImplementInterface_WithoutFuse_AcquireSpecifyInterfaceOnly(Type type, Type assignableInterface)

--- a/test/GraphQL.Conventions.Tests/Types/Resolution/Extensions/ReflectionExtensionsTests.cs
+++ b/test/GraphQL.Conventions.Tests/Types/Resolution/Extensions/ReflectionExtensionsTests.cs
@@ -1,0 +1,74 @@
+using System;
+using GraphQL.Conventions.Types.Resolution.Extensions;
+using Xunit;
+
+namespace Tests.Types.Resolution.Extensions
+{
+    public class ReflectionExtensionsTests
+    {
+        [Theory]
+        [MemberData(nameof(GetImplementInterface_WithoutFuse_AcquireSpecifyInterfaceOnly__Data))]
+        public void GetImplementInterface_WithoutFuse_AcquireSpecifyInterfaceOnly(Type type, Type assignableInterface)
+            => Assert.IsTrue(type.ImplementInterface(assignableInterface, false));
+
+        public static TheoryData<Type, Type> GetImplementInterface_WithoutFuse_AcquireSpecifyInterfaceOnly__Data() =>
+            new()
+            {
+                { typeof(ITestInterface1<int>), typeof(ITestInterface1<int>) },
+                { typeof(ITestInterface2<int>), typeof(ITestInterface1<int>) },
+                { typeof(ITestInterface2<int>), typeof(ITestInterface2<int>) },
+                { typeof(TestClass11<int>), typeof(ITestInterface1<int>) },
+                { typeof(TestClass12), typeof(ITestInterface1<string>) },
+                { typeof(TestClass12), typeof(ITestInterface2<string>) },
+                { typeof(TestClass2), typeof(ITestInterface1<int>) },
+                { typeof(TestClass2), typeof(ITestInterface1<string>) },
+                { typeof(TestClass2), typeof(ITestInterface2<string>) },
+            };
+
+        [Theory]
+        [MemberData(nameof(GetImplementInterface_WithFuse_AcquireSpecifyInterfaceOnly__Data))]
+        public void GetImplementInterface_WithFuse_AcquireSpecifyInterfaceOnly(Type type, Type assignableInterface) =>
+            Assert.IsTrue(type.ImplementInterface(assignableInterface));
+
+        public static TheoryData<Type, Type> GetImplementInterface_WithFuse_AcquireSpecifyInterfaceOnly__Data() =>
+            new()
+            {
+                { typeof(ITestInterface1<int>), typeof(ITestInterface1<>) },
+                { typeof(ITestInterface2<int>), typeof(ITestInterface1<>) },
+                { typeof(ITestInterface2<int>), typeof(ITestInterface2<>) },
+                { typeof(TestClass11<int>), typeof(ITestInterface1<>) },
+                //
+                { typeof(ITestInterface1<string>), typeof(ITestInterface1<>) },
+                { typeof(ITestInterface2<string>), typeof(ITestInterface1<>) },
+                { typeof(ITestInterface2<string>), typeof(ITestInterface2<>) },
+                { typeof(TestClass11<string>), typeof(ITestInterface1<>) },
+                //
+                { typeof(TestClass12), typeof(ITestInterface1<>) },
+                { typeof(TestClass12), typeof(ITestInterface2<>) },
+                { typeof(TestClass2), typeof(ITestInterface1<>) },
+                { typeof(TestClass2), typeof(ITestInterface2<>) },
+            };
+
+        private interface ITestInterface1<out T>
+        {
+            // ReSharper disable once UnusedMember.Global
+            T Item => throw new NotImplementedException();
+        }
+
+        private interface ITestInterface2<out T> : ITestInterface1<T>
+        {
+        }
+
+        private class TestClass11<T> : ITestInterface1<T>
+        {
+        }
+
+        private class TestClass12 : ITestInterface2<string>
+        {
+        }
+
+        private class TestClass2 : ITestInterface2<string>, ITestInterface1<int>
+        {
+        }
+    }
+}


### PR DESCRIPTION
Hello,

I've noticed that IReadOnlyList<T> is not recognized as compatible with IEnumerable<T> in schema generation, which may limit the library's functionality in some scenarios.

This PR updates the IsEnumerableGraphType(TypeInfo) method in ReflectionExtensions.cs to use a simple check: `type.GetGenericTypeDefinition() == interfaceType.GetGenericTypeDefinition()`.
It will effect to GraphTypeInfo.cs#166 where marking the GraphTypeInfo.IsListType flag's logic.

Please consider merging this PR.