### PR TITLE
Consistently resolve ignore flags in derived types

### DIFF
--- a/test/GraphQL.Conventions.Tests/Attributes/MetaData/IgnoreAttributeTests.cs
+++ b/test/GraphQL.Conventions.Tests/Attributes/MetaData/IgnoreAttributeTests.cs
@@ -1,4 +1,8 @@
+using System.Linq;
 using GraphQL.Conventions;
+using GraphQL.Conventions.Adapters;
+using GraphQL.Conventions.Builders;
+using GraphQL.Types;
 using Tests.Templates;
 using Tests.Templates.Extensions;
 // ReSharper disable UnusedMember.Local
@@ -24,6 +28,44 @@ namespace Tests.Attributes.MetaData
             type.ShouldHaveFieldWithName("DEPRECATED_MEMBER").AndWithDeprecationReason("Some enum member reason");
         }
 
+        [Test]
+        public void Derived_Fields_Can_Be_Ignored()
+        {
+            var type = TypeInfo<Implementation>();
+            type.Fields.Count.ShouldEqual(2);
+            type.ShouldHaveFieldWithName("firstProperty");
+            type.ShouldHaveFieldWithName("someOtherProperty");
+            type.ShouldNotHaveFieldWithName("someProperty");
+
+            var iface = TypeInfo<ISomeInterface>();
+            iface.Fields.Count.ShouldEqual(1);
+            iface.ShouldHaveFieldWithName("firstProperty");
+            iface.ShouldNotHaveFieldWithName("someProperty");
+        }
+
+        [Test]
+        public void Can_Ignore_Unwanted_Fields_On_Derived_Types()
+        {
+            var schema = new SchemaConstructor<ISchema, IGraphType>(new GraphTypeAdapter())
+                .IgnoreTypes((t, m) => m?.Name == nameof(ISomeInterfaceExternal.SomeProperty))
+                .Build(typeof(SchemaType));
+
+            schema.Initialize();
+            var type = schema.AllTypes[nameof(ImplementationExternal)] as ObjectGraphType;
+            Assert.AreEqual(1, type.Fields.Count(f => f.Name == "someOtherProperty"));
+            Assert.AreEqual(0, type.Fields.Count(f => f.Name == "someProperty"));
+        }
+
+        private class SchemaType
+        {
+            public QueryType Query { get; }
+        }
+
+        private class QueryType
+        {
+            public ImplementationExternal Foo => new();
+        }
+
         private class FieldData
         {
             public int NormalField { get; set; }
@@ -41,6 +83,40 @@ namespace Tests.Attributes.MetaData
                 [Deprecated("Some enum member reason")]
                 DeprecatedMember,
             }
+        }
+
+        private class Implementation : ISomeInterface
+        {
+            public string FirstProperty { get; set; }
+
+            [Ignore]
+            public string SomeProperty { get; set; }
+
+            public string SomeOtherProperty { get; set; }
+        }
+
+        private interface ISomeInterface
+        {
+            public string FirstProperty { get; set; }
+
+            [Ignore]
+            public string SomeProperty { get; set; }
+        }
+
+        private class ImplementationExternal : ISomeInterfaceExternal
+        {
+            public string FirstProperty { get; set; }
+
+            public string SomeProperty { get; set; }
+
+            public string SomeOtherProperty { get; set; }
+        }
+
+        private interface ISomeInterfaceExternal
+        {
+            public string FirstProperty { get; set; }
+
+            public string SomeProperty { get; set; }
         }
     }
 }


### PR DESCRIPTION
Ensure that `[Ignore]` attributes are consistently recognised and resolved in types implementing interfaces, and that `IgnoreTypes()` callbacks are applied as expected.

Tests: `Derived_Fields_Can_Be_Ignored()` and `Can_Ignore_Unwanted_Fields_On_Derived_Types()` in `IgnoreAttributeTests`.