### PR TITLE
IReadOnlyDictionry is not a list type

### DIFF
--- a/src/GraphQL.Conventions/Types/Resolution/Extensions/ReflectionExtensions.cs
+++ b/src/GraphQL.Conventions/Types/Resolution/Extensions/ReflectionExtensions.cs
@@ -108,7 +108,9 @@ namespace GraphQL.Conventions.Types.Resolution.Extensions
 
         public static bool IsEnumerableGraphType(this TypeInfo type)
         {
-            if (type.IsImplementingInterface(typeof(IDictionary)) || type.IsImplementingInterface(typeof(IDictionary<,>)))
+            if (type.IsImplementingInterface(typeof(IDictionary))
+                || type.IsImplementingInterface(typeof(IDictionary<,>))
+                || type.IsImplementingInterface(typeof(IReadOnlyDictionary<,>)))
             {
                 return false;
             }

--- a/test/GraphQL.Conventions.Tests/GraphQL.Conventions.Tests.csproj
+++ b/test/GraphQL.Conventions.Tests/GraphQL.Conventions.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <StartupObject>Tests.Program</StartupObject>
     <RootNamespace>Tests</RootNamespace>
   </PropertyGroup>

--- a/test/GraphQL.Conventions.Tests/Types/Resolution/Extensions/ReflectionExtensionsTests.cs
+++ b/test/GraphQL.Conventions.Tests/Types/Resolution/Extensions/ReflectionExtensionsTests.cs
@@ -40,6 +40,7 @@ namespace Tests.Types.Resolution.Extensions
         {
             typeof(IDictionary<,>),
             typeof(IDictionary),
+            typeof(IReadOnlyDictionary<,>)
         };
 
         [Theory]


### PR DESCRIPTION
This is one is more or less extending a previous PR: 
https://github.com/graphql-dotnet/conventions/pull/262 

There we changed the ReflectionExtensions so 
`IDictionary` and `IDictionary<,>` are **not regarded as ListType**
unfortunately we left over the board` IReadOnlyDictionary<,>` which also **should not be regarded as ListType** 